### PR TITLE
check for where=1=1

### DIFF
--- a/src/generateRenderer/index.js
+++ b/src/generateRenderer/index.js
@@ -18,8 +18,10 @@ function generateRenderer (data = {}, params = {}) {
   if (data.statistics && data.statistics.classBreaks) {
     breaks = data.statistics.classBreaks.sort((a, b) => a - b)
     return renderClassBreaks(breaks, {}, '')
-  } else if (data.features) breaks = Winnow.query(data, params)
-  else throw new Error('Must supply statistics or data features')
+  } else if (data.features) {
+    if (params.where === '1=1') delete params.where
+    breaks = Winnow.query(data, params)
+  } else throw new Error('Must supply statistics or data features')
   // TODO: ? handle uniqueValue statistics
 
   if (params.classificationDef && params.classificationDef.type) {

--- a/test/generateRenderer.js
+++ b/test/generateRenderer.js
@@ -85,6 +85,7 @@ describe('when a class breaks classification passed in', () => {
   })
   describe('has correct parameters', () => {
     it('should properly return a renderer', () => {
+      options.where = '1=1'
       const response = generateRenderer(data, options)
       response.type.should.equal('classBreaks')
       response.minValue.should.equal(0)


### PR DESCRIPTION
small check for where within `generateRenderer`. Should be handled by winnow, but some cases seemed to ignore. Has been tested in Insights.