### PR TITLE
F/support pagination applied

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,9 @@ e.g.
     ]
   },
   filtersApplied: {
-    geometry: Boolean, // true if a geometric filter has already been applied to the data'
-    where: Boolean // true if a sql-like where filter has already been applied to the data
+    geometry: Boolean, // true if a geometric filter has already been applied to the data
+    where: Boolean, // true if a sql-like where filter has already been applied to the data
+    offset: Boolean // true if the result offset has already been applied to the data
   }
   count: Number // pass count if the number of features in a query has been pre-calculated
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "featureserver",
-  "version": "2.4.6",
+  "version": "2.5.0",
   "description": "*An open source implementation of the GeoServices specification*",
   "main": "dist/index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "featureserver",
-  "version": "2.5.0",
+  "version": "2.4.6",
   "description": "*An open source implementation of the GeoServices specification*",
   "main": "dist/index.js",
   "directories": {

--- a/src/query.js
+++ b/src/query.js
@@ -15,7 +15,7 @@ function query (data, params = {}) {
   // TODO clean up this series of if statements
   if (data.filtersApplied && data.filtersApplied.geometry) delete params.geometry
   if ((data.filtersApplied && data.filtersApplied.where) || params.where === '1=1') delete params.where
-  if (data.filtersApplied && data.filtersApplied.offset) { params.resultOffset = 0; }
+  if (data.filtersApplied && data.filtersApplied.offset) params.resultOffset = 0
   if (data.statistics) return renderStats(data)
   if (params.returnCountOnly && data.count) return { count: data.count }
 

--- a/src/query.js
+++ b/src/query.js
@@ -15,6 +15,7 @@ function query (data, params = {}) {
   // TODO clean up this series of if statements
   if (data.filtersApplied && data.filtersApplied.geometry) delete params.geometry
   if ((data.filtersApplied && data.filtersApplied.where) || params.where === '1=1') delete params.where
+  if (data.filtersApplied && data.filtersApplied.offset) { params.resultOffset = 0; }
   if (data.statistics) return renderStats(data)
   if (params.returnCountOnly && data.count) return { count: data.count }
 

--- a/src/query.js
+++ b/src/query.js
@@ -15,7 +15,7 @@ function query (data, params = {}) {
   // TODO clean up this series of if statements
   if (data.filtersApplied && data.filtersApplied.geometry) delete params.geometry
   if ((data.filtersApplied && data.filtersApplied.where) || params.where === '1=1') delete params.where
-  if (data.filtersApplied && data.filtersApplied.offset) params.resultOffset = 0
+  if (data.filtersApplied && data.filtersApplied.offset) delete params.resultOffset
   if (data.statistics) return renderStats(data)
   if (params.returnCountOnly && data.count) return { count: data.count }
 

--- a/test/fixtures/offset-applied.json
+++ b/test/fixtures/offset-applied.json
@@ -1,0 +1,14 @@
+{
+  "filtersApplied": {
+    "offset": true
+  },
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": null,
+      "properties": {
+      }
+    }
+  ]
+}

--- a/test/query.js
+++ b/test/query.js
@@ -11,6 +11,7 @@ const statsDateNoMeta = require('./fixtures/stats-date-no-metadata.json')
 const statsDateInMetaValue = require('./fixtures/stats-date-with-metadata-value.json')
 const oneOfEach = require('./fixtures/one-of-each.json')
 const fullySpecified = require('./fixtures/fully-specified-metadata.json')
+const offsetApplied = require('./fixtures/offset-applied.json')
 
 // const moment = require('moment')
 
@@ -386,6 +387,13 @@ describe('Query operatons', () => {
       const json = FeatureServer.query(dateNoMeta, {})
       json.features[0].attributes.dateField.should.equal(1497578316179)
       json.fields[0].type.should.equal('esriFieldTypeDate')
+    })
+  })
+
+  describe('when an offset has already been applied', () => {
+    it('should remove the result offset', () => {
+      const json = FeatureServer.query(offsetApplied, {resultOffset: 50, resultRecordCount: 1})
+      json.features.length.should.be.greaterThan(0)
     })
   })
 })


### PR DESCRIPTION
Adds a parameter to the filtersApplied object for offset, that when set to true, will reset the resultOffset back to 0 to avoid slicing problems during the finishQuery function later. This fix is particularly important for those users who have already applied pagination during their database query in the getData method of Koop.