### PR TITLE
DNM: Support use of a provider's metadata idField as full-fledge OBJECTID

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "author": "Daniel Fenton <dfenton@esri.com>",
   "license": "Apache-2.0",
   "dependencies": {
+    "@koopjs/logger": "^2.0.2",
     "chroma-js": "^1.3.4",
     "classybrew": "0.0.3",
     "esri-extent": "^1.1.1",
@@ -34,13 +35,25 @@
     "supertest": "^3.0.0"
   },
   "standard": {
-    "globals": ["describe", "it", "before", "after", "beforeEach", "afterEach"]
+    "globals": [
+      "describe",
+      "it",
+      "before",
+      "after",
+      "beforeEach",
+      "afterEach"
+    ]
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/koopjs/FeatureServer.git"
   },
-  "keywords": ["featureserver", "geoservices", "geojson", "sql"],
+  "keywords": [
+    "featureserver",
+    "geoservices",
+    "geojson",
+    "sql"
+  ],
   "bugs": {
     "url": "https://github.com/koopjs/FeatureServer/issues"
   },

--- a/src/query.js
+++ b/src/query.js
@@ -1,4 +1,4 @@
-const Winnow = require('../../winnow/src')
+const Winnow = require('winnow')
 const Logger = require('@koopjs/logger')
 const config = require('config')
 const log = new Logger(config)

--- a/src/query.js
+++ b/src/query.js
@@ -1,4 +1,7 @@
-const Winnow = require('winnow')
+const Winnow = require('../../winnow/src')
+const Logger = require('@koopjs/logger')
+const config = require('config')
+const log = new Logger(config)
 const { renderFeatures, renderStatistics, renderStats } = require('./templates')
 const Utils = require('./utils')
 const _ = require('lodash')
@@ -16,6 +19,8 @@ function query (data, params = {}) {
   // TODO clean up this series of if statements
   const filtersApplied = data.filtersApplied || {}
   const options = _.cloneDeep(params)
+  const hasIdField = _.has(data, 'metadata.idField')
+
   if (filtersApplied.projection) delete options.outSR
   if (filtersApplied.geometry) delete options.geometry
   if (filtersApplied.where || options.where === '1=1') delete options.where
@@ -30,13 +35,20 @@ function query (data, params = {}) {
   if (options.f !== 'geojson') options.toEsri = true
   const queriedData = filtersApplied.all ? data : Winnow.query(data, options)
 
+  // Warn if no idField set
+  if (!hasIdField && options.toEsri) log.warn(`The requested provider has no "idField" assignment. This can cause errors in ArcGIS clients`)
+
+  // Warn if OBJECTIDs created from idField don't conform to required type and range
+  if (hasIdField && options.toEsri && queriedData.features.some(feature => { return !Number.isInteger(feature.OBJECTID) || feature.OBJECTID > 2147483647 })) {
+    log.warn(`OBJECTIDs created from provider's idField are not integers from 0 to 2147483647`)
+  }
+
   if (params.f === 'geojson') return { type: 'FeatureCollection', features: queriedData.features }
   else return geoservicesPostQuery(data, queriedData, params)
 }
 
 function geoservicesPostQuery (data, queriedData, params) {
   // options.objectIds works alongside returnCountOnly but not statistics
-  const oidField = (data.metadata && data.metadata.idField) || 'OBJECTID'
   if (params.objectIds && !params.outStatistics) {
     let oids
 
@@ -48,7 +60,7 @@ function geoservicesPostQuery (data, queriedData, params) {
       return parseInt(i)
     })
     queriedData.features = queriedData.features.filter(f => {
-      return oids.indexOf(f.attributes[oidField]) > -1
+      return oids.indexOf(f.attributes.OBJECTID) > -1
     })
   }
 
@@ -69,13 +81,12 @@ function geoservicesPostQuery (data, queriedData, params) {
 }
 
 function idsOnly (data, options = {}) {
-  const oidField = options.idField || 'OBJECTID'
   return data.features.reduce(
     (resp, f) => {
-      resp.objectIds.push(f.attributes[oidField])
+      resp.objectIds.push(f.attributes.OBJECTID)
       return resp
     },
-    { objectIdField: oidField, objectIds: [] }
+    { objectIdField: 'OBJECTID', objectIds: [] }
   )
 }
 

--- a/src/templates.js
+++ b/src/templates.js
@@ -54,7 +54,6 @@ function renderLayer (featureCollection = {}, options = {}) {
   if (json.timeInfo) json.timeInfo = metadata.timeInfo
   if (json.maxRecordCount) json.maxRecordCount = metadata.maxRecordCount || 2000
   if (json.displayField) json.displayField = metadata.displayField || json.fields[0].name
-  if (json.objectIdField) json.objectIdField = metadata.idField || 'OBJECTID'
   if (capabilities.quantization) json.supportsCoordinatesQuantization = true
   return json
 }

--- a/test/field.js
+++ b/test/field.js
@@ -26,10 +26,10 @@ describe('when building esri fields', function () {
       f.should.have.property('name')
       f.should.have.property('alias')
     })
-    fields[0].type.should.equal('esriFieldTypeInteger')
-    fields[1].type.should.equal('esriFieldTypeDouble')
-    fields[2].type.should.equal('esriFieldTypeString')
-    fields[3].type.should.equal('esriFieldTypeDate')
+    fields.find((f) => { return f.name === 'propInt' }).type.should.equal('esriFieldTypeInteger')
+    fields.find((f) => { return f.name === 'propFloat' }).type.should.equal('esriFieldTypeDouble')
+    fields.find((f) => { return f.name === 'propString' }).type.should.equal('esriFieldTypeString')
+    fields.find((f) => { return f.name === 'propDate' }).type.should.equal('esriFieldTypeDate')
   })
 
   describe('proper dates get through, improper dates fail', () => {
@@ -42,9 +42,9 @@ describe('when building esri fields', function () {
     const fields = fieldObj.fields
 
     it('Should not allow improper date formats through', () => {
-      fields[0].type.should.equal('esriFieldTypeDate')
-      fields[1].type.should.equal('esriFieldTypeString')
-      fields[2].type.should.equal('esriFieldTypeString')
+      fields.find((f) => { return f.name === 'properDate' }).type.should.equal('esriFieldTypeDate')
+      fields.find((f) => { return f.name === 'improperDate1' }).type.should.equal('esriFieldTypeString')
+      fields.find((f) => { return f.name === 'improperDate2' }).type.should.equal('esriFieldTypeString')
     })
   })
 })

--- a/test/info.js
+++ b/test/info.js
@@ -270,7 +270,7 @@ describe('Info operations', () => {
       layer.extent.ymax.should.equal(14)
       layer.geometryType.should.equal('esriGeometryPolygon')
       layer.maxRecordCount.should.equal(100)
-      layer.objectIdField.should.equal('test')
+      layer.objectIdField.should.equal('OBJECTID')
       layer.displayField.should.equal('test')
       layer.timeInfo.test.should.equal('test')
     })

--- a/test/route.js
+++ b/test/route.js
@@ -61,7 +61,7 @@ describe('Routing feature server requests', () => {
       request(app)
         .get('/FeatureServer/0/query?f=json&where=1%3D1')
         .expect(res => {
-          res.body.features[1].attributes.OBJECTID.should.equal(1)
+          res.body.features[1].attributes.OBJECTID.should.equal(637696142)
           res.body.features.length.should.equal(417)
           res.body.exceededTransferLimit.should.equal(false)
         })
@@ -74,7 +74,7 @@ describe('Routing feature server requests', () => {
       request(app)
         .get('/FeatureServer/0/query?f=json&where=1%3D1')
         .expect(res => {
-          res.body.features[1].attributes.OBJECTID.should.equal(1)
+          res.body.features[1].attributes.OBJECTID.should.equal(637696142)
           res.body.features.length.should.equal(2)
           res.body.exceededTransferLimit.should.equal(true)
         })
@@ -86,7 +86,7 @@ describe('Routing feature server requests', () => {
       request(app)
         .get('/FeatureServer/0/query?f=json&orderByFields=')
         .expect(res => {
-          res.body.features[1].attributes.OBJECTID.should.equal(1)
+          res.body.features[1].attributes.OBJECTID.should.equal(637696142)
           res.body.features.length.should.equal(417)
         })
         .expect('Content-Type', /json/)


### PR DESCRIPTION
DO NOT MERGE.  Changes and tests here currently dependent on anticipated [PR](https://github.com/koopjs/winnow/pull/68) merge in winnow.

Assumptions:
* For an OBJECTID to fully support ArcGIS clients, it must have `name` and `alias` equal to `OBJECTID`
* If a model's `idField` is set to a given attribute, and the format option is not `geojson`, we can use the value of the idField attribute as the OBJECTID value, and then delete the original idField attribute so that the information is duplicated in the `attributes` object

This PR:
1. Adds warning if a request is aimed at a provider that has not assigned an `idField` to its metadata.
2. Adds warning if a request returns OBJECTIDs that are not integers or are out of range
3. Alters the creation of the `fields` objects to account for the use of a model's attribute as the OBJECTID (the idField), and when doing so, conforms to the assumptions listed above
