### PR TITLE
Fields array refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Added
+* provider attributes referenced by metadata `idField` are maintained as separate field in addition to OBJECTID when creating ESRI json
+* warnings when a provider's `idField` is not set or references non- or out-of-range integer values
+* warning when a provider's `idField` is a mixed-case version of 'OBJECTID'
+
 ## [2.10.2] - 04-10-2018
 ### Fixed 
 * set Content-Type: application/javascript when response is wrapped in callback (JSONP)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 * warnings when a provider's `idField` is not set or references non- or out-of-range integer values
 * warning when a provider's `idField` is a mixed-case version of 'OBJECTID'
 
+### Fixed
+* changed default value of `hasStaticData` to `false`
+
 ## [2.10.2] - 04-10-2018
 ### Fixed 
 * set Content-Type: application/javascript when response is wrapped in callback (JSONP)

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   "author": "Daniel Fenton <dfenton@esri.com>",
   "license": "Apache-2.0",
   "dependencies": {
-    "@koopjs/logger": "^2.0.2",
     "chroma-js": "^1.3.4",
     "classybrew": "0.0.3",
     "esri-extent": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "author": "Daniel Fenton <dfenton@esri.com>",
   "license": "Apache-2.0",
   "dependencies": {
+    "@koopjs/logger": "^2.0.2",
     "chroma-js": "^1.3.4",
     "classybrew": "0.0.3",
     "esri-extent": "^1.1.1",
@@ -34,13 +35,25 @@
     "supertest": "^3.0.0"
   },
   "standard": {
-    "globals": ["describe", "it", "before", "after", "beforeEach", "afterEach"]
+    "globals": [
+      "describe",
+      "it",
+      "before",
+      "after",
+      "beforeEach",
+      "afterEach"
+    ]
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/koopjs/FeatureServer.git"
   },
-  "keywords": ["featureserver", "geoservices", "geojson", "sql"],
+  "keywords": [
+    "featureserver",
+    "geoservices",
+    "geojson",
+    "sql"
+  ],
   "bugs": {
     "url": "https://github.com/koopjs/FeatureServer/issues"
   },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "clean": "rm -rf dist",
     "compile": "buble -i src -o dist",
     "package": "npm run clean && npm run compile",
-    "test": "standard && mocha test"
+    "test": "standard && mocha test --bail"
   },
   "author": "Daniel Fenton <dfenton@esri.com>",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "clean": "rm -rf dist",
     "compile": "buble -i src -o dist",
     "package": "npm run clean && npm run compile",
-    "test": "standard && mocha test --bail"
+    "test": "standard && mocha test"
   },
   "author": "Daniel Fenton <dfenton@esri.com>",
   "license": "Apache-2.0",

--- a/src/field/index.js
+++ b/src/field/index.js
@@ -17,28 +17,38 @@ const templates = {
 
 // TODO this should be the only exported function
 function computeFieldObject (data, template, options = {}) {
-  let oid = false
   const metadata = data.metadata || {}
-  let metadataFields = metadata.fields
+  let responseFields = metadata.fields
 
-  if (!metadataFields && data.statistics) return computeFieldsFromProperties(data.statistics[0], template, options).fields
-  else if (!metadataFields) return computeAggFieldObject(data, template, options)
+  if (!metadata.fields && data.statistics) return computeFieldsFromProperties(data.statistics[0], template, options).fields
+  else if (!metadata.fields) return computeAggFieldObject(data, template, options)
 
+  // Add OBJECTID if it isn't already a metadata field
+  if (!_.find(responseFields, {'name': 'OBJECTID'})) responseFields.push({name: 'OBJECTID'})
+
+  // If outFields were specified and not wildcarded, create a subset of fields from metadata fields based on outFields param
   if (options.outFields && options.outFields !== '*') {
+    // Split comma-delimited outFields
     const outFields = options.outFields.split(/\s*,\s*/)
-    metadataFields = metadata.fields.filter(field => {
-      if (outFields.indexOf(field.name) > -1) return field
+
+    // Filter out fields that weren't included in the outFields param
+    responseFields = responseFields.filter(field => {
+      return outFields.includes(field.name)
     })
   }
-  const fields = metadataFields.map(field => {
-    let type
-    if (field.name === metadata.idField || field.name.toLowerCase() === 'objectid') {
-      type = 'esriFieldTypeOID'
-      oid = true
+
+  // Loop through the requested response fields and create a field object for each
+  const fields = responseFields.map(field => {
+    // Fields named OBJECTID get special definition with specific JSON template
+    if (field.name === 'OBJECTID') {
+      return templates.objectIDField
     }
-    const template = _.cloneDeep(templates.field)
-    type = type || fieldMap[field.type.toLowerCase()] || field.type
-    return Object.assign({}, template, {
+
+    // Determine the ESRI field type
+    const type = fieldMap[field.type.toLowerCase()] || field.type
+
+    // Create the field object by overriding a template with field specific property values
+    return Object.assign({}, templates.field, {
       name: field.name,
       type,
       alias: field.alias || field.name,
@@ -46,7 +56,6 @@ function computeFieldObject (data, template, options = {}) {
       length: (type === 'esriFieldTypeString') ? 128 : (type === 'esriFieldTypeDate') ? 36 : undefined
     })
   })
-  if (!oid) fields.push(templates.objectIDField)
 
   // Ensure the OBJECTID field is first in the array
   fields.unshift(fields.splice(fields.findIndex(field => field.name === 'OBJECTID'), 1)[0])
@@ -58,49 +67,39 @@ function computeFieldObject (data, template, options = {}) {
 const DATE_FORMATS = [moment.ISO_8601]
 
 /**
- * builds esri json fields object from geojson properties
+ * builds esri json fields object from geojson properties.  Populates the `fields` array for layer info service
  *
  * @param  {object} props
  * @param  {string} template
  * @param  {object} options
  * @return {object} fields
  */
-function computeFieldsFromProperties (props, template, options = {}) {
+function computeFieldsFromProperties (props, template, metadataIdField, options = {}) {
+  // Loop through the properties and construct an array of field objects
   const fields = Object.keys(props).map((key, i) => {
     const type = fieldType(props[key])
-    const field = {
+
+    // Use field template and override. Add properties needed specifically for layer service
+    return Object.assign({}, templates.field, {
       name: key,
-      type,
+      type: fieldType(props[key]),
       alias: key,
-      defaultValue: null,
-      domain: null,
       editable: false,
       nullable: false,
-      sqlType: 'sqlTypeOther'
-    }
-
-    // Add length field to strings and dates
-    field.length = (type === 'esriFieldTypeString') ? 128 : (type === 'esriFieldTypeDate') ? 36 : undefined
-
-    return field
+      length: (type === 'esriFieldTypeString') ? 128 : (type === 'esriFieldTypeDate') ? 36 : undefined
+    })
   })
 
-  // Add OBJECTID field if not yet there
-  if (template === 'layer' && Object.keys(props).indexOf('OBJECTID') < 0) {
-    fields.push({
-      name: 'OBJECTID',
-      type: 'esriFieldTypeOID',
-      alias: 'OBJECTID',
-      defaultValue: null,
-      domain: null,
+  // If this is part of a layer service, add OBJECTID field if its not already a model field. Decorate the with additional properties needed for layer service
+  if (template === 'layer' && !_.find(fields, { name: 'OBJECTID' })) {
+    fields.push(Object.assign({}, templates.objectIDField, {
       editable: false,
-      nullable: false,
-      sqlType: 'sqlTypeOther'
-    })
-
-    // Ensure OBJECTID is first in the array
-    fields.unshift(fields.splice(fields.findIndex(field => field.name === 'OBJECTID'), 1)[0])
+      nullable: false
+    }))
   }
+
+  // Ensure the OBJECTID field is first in the array
+  fields.unshift(fields.splice(fields.findIndex(field => field.name === 'OBJECTID'), 1)[0])
 
   return { oidField: 'OBJECTID', fields }
 }
@@ -136,6 +135,7 @@ function isInt (value) {
 function computeAggFieldObject (data, template, options = {}) {
   const feature = data.features && data.features[0]
   const properties = feature ? feature.properties || feature.attributes : options.attributeSample
-  if (properties) return computeFieldsFromProperties(properties, template, options).fields
+  const idField = data.metadata && data.metadata.idField
+  if (properties) return computeFieldsFromProperties(properties, template, idField, options).fields
   else return []
 }

--- a/src/field/index.js
+++ b/src/field/index.js
@@ -74,7 +74,7 @@ const DATE_FORMATS = [moment.ISO_8601]
  * @param  {object} options
  * @return {object} fields
  */
-function computeFieldsFromProperties (props, template, metadataIdField, options = {}) {
+function computeFieldsFromProperties (props, template, options = {}) {
   // Loop through the properties and construct an array of field objects
   const fields = Object.keys(props).map((key, i) => {
     const type = fieldType(props[key])
@@ -135,7 +135,6 @@ function isInt (value) {
 function computeAggFieldObject (data, template, options = {}) {
   const feature = data.features && data.features[0]
   const properties = feature ? feature.properties || feature.attributes : options.attributeSample
-  const idField = data.metadata && data.metadata.idField
-  if (properties) return computeFieldsFromProperties(properties, template, idField, options).fields
+  if (properties) return computeFieldsFromProperties(properties, template, options).fields
   else return []
 }

--- a/src/query.js
+++ b/src/query.js
@@ -36,7 +36,7 @@ function query (data, params = {}) {
 
 function geoservicesPostQuery (data, queriedData, params) {
   // options.objectIds works alongside returnCountOnly but not statistics
-  const oidField = (data.metadata && data.metadata.idField) || 'OBJECTID'
+  const oidField = 'OBJECTID'
   if (params.objectIds && !params.outStatistics) {
     let oids
 
@@ -69,7 +69,7 @@ function geoservicesPostQuery (data, queriedData, params) {
 }
 
 function idsOnly (data, options = {}) {
-  const oidField = options.idField || 'OBJECTID'
+  const oidField = 'OBJECTID'
   return data.features.reduce(
     (resp, f) => {
       resp.objectIds.push(f.attributes[oidField])

--- a/src/query.js
+++ b/src/query.js
@@ -1,7 +1,4 @@
 const Winnow = require('winnow')
-const Logger = require('@koopjs/logger')
-const config = require('config')
-const log = new Logger(config)
 const { renderFeatures, renderStatistics, renderStats } = require('./templates')
 const Utils = require('./utils')
 const _ = require('lodash')
@@ -37,8 +34,12 @@ function query (data, params = {}) {
 
   // ArcGIS client warnings
   if (options.toEsri) {
-    if (!hasIdField) log.warn(`The requested provider has no "idField" assignment. This can cause errors in ArcGIS clients`)
-    else if (data.metadata.idField.toLowerCase() === 'objectid' && data.metadata.idField !== 'OBJECTID') { log.warn(`The requested provider's "idField" is a mixed-case version of "OBJECTID". This can cause errors in ArcGIS clients`) } else if (queriedData.features.some(feature => { return !Number.isInteger(feature.attributes.OBJECTID) || feature.attributes.isArrayOBJECTID > 2147483647 })) { log.warn(`OBJECTIDs created from provider's "idField" are not integers from 0 to 2147483647`) }
+    if (!hasIdField) console.warn(`The requested provider has no "idField" assignment. This can cause errors in ArcGIS clients`)
+    else if (data.metadata.idField.toLowerCase() === 'objectid' && data.metadata.idField !== 'OBJECTID') {
+      console.warn(`The requested provider's "idField" is a mixed-case version of "OBJECTID". This can cause errors in ArcGIS clients`)
+    } else if (queriedData.features.some(feature => { return !Number.isInteger(feature.attributes.OBJECTID) || feature.attributes.isArrayOBJECTID > 2147483647 })) {
+      console.warn(`OBJECTIDs created from provider's "idField" are not integers from 0 to 2147483647`)
+    }
   }
 
   if (params.f === 'geojson') return { type: 'FeatureCollection', features: queriedData.features }

--- a/src/templates.js
+++ b/src/templates.js
@@ -54,7 +54,7 @@ function renderLayer (featureCollection = {}, options = {}) {
   if (json.timeInfo) json.timeInfo = metadata.timeInfo
   if (json.maxRecordCount) json.maxRecordCount = metadata.maxRecordCount || 2000
   if (json.displayField) json.displayField = metadata.displayField || json.fields[0].name
-  if (json.objectIdField) json.objectIdField = metadata.idField || 'OBJECTID'
+  if (json.objectIdField) json.objectIdField = 'OBJECTID'
   if (capabilities.quantization) json.supportsCoordinatesQuantization = true
   return json
 }

--- a/templates/layer.json
+++ b/templates/layer.json
@@ -64,6 +64,6 @@
   "globalIdField": "",
   "types": [],
   "templates": [],
-  "hasStaticData": true,
+  "hasStaticData": false,
   "timeInfo": {}
 }

--- a/test/field.js
+++ b/test/field.js
@@ -26,10 +26,10 @@ describe('when building esri fields', function () {
       f.should.have.property('name')
       f.should.have.property('alias')
     })
-    fields[0].type.should.equal('esriFieldTypeInteger')
-    fields[1].type.should.equal('esriFieldTypeDouble')
-    fields[2].type.should.equal('esriFieldTypeString')
-    fields[3].type.should.equal('esriFieldTypeDate')
+    fields.findIndex(f => { return f.type === 'esriFieldTypeInteger' }).should.not.equal(-1)
+    fields.findIndex(f => { return f.type === 'esriFieldTypeDouble' }).should.not.equal(-1)
+    fields.findIndex(f => { return f.type === 'esriFieldTypeString' }).should.not.equal(-1)
+    fields.findIndex(f => { return f.type === 'esriFieldTypeDate' }).should.not.equal(-1)
   })
 
   describe('proper dates get through, improper dates fail', () => {
@@ -42,9 +42,9 @@ describe('when building esri fields', function () {
     const fields = fieldObj.fields
 
     it('Should not allow improper date formats through', () => {
-      fields[0].type.should.equal('esriFieldTypeDate')
-      fields[1].type.should.equal('esriFieldTypeString')
-      fields[2].type.should.equal('esriFieldTypeString')
+      fields.find(f => { return f.name === 'properDate' }).type.should.equal('esriFieldTypeDate')
+      fields.find(f => { return f.name === 'improperDate1' }).type.should.equal('esriFieldTypeString')
+      fields.find(f => { return f.name === 'improperDate2' }).type.should.equal('esriFieldTypeString')
     })
   })
 })

--- a/test/info.js
+++ b/test/info.js
@@ -270,7 +270,7 @@ describe('Info operations', () => {
       layer.extent.ymax.should.equal(14)
       layer.geometryType.should.equal('esriGeometryPolygon')
       layer.maxRecordCount.should.equal(100)
-      layer.objectIdField.should.equal('test')
+      layer.objectIdField.should.equal('OBJECTID')
       layer.displayField.should.equal('test')
       layer.timeInfo.test.should.equal('test')
     })

--- a/test/info.js
+++ b/test/info.js
@@ -239,7 +239,7 @@ describe('Info operations', () => {
         'globalIdField': Joi.string().allow(''),
         'types': Joi.array(),
         'templates': Joi.array(),
-        'hasStaticData': Joi.boolean().valid(true),
+        'hasStaticData': Joi.boolean().valid(false),
         'timeInfo': Joi.object().optional()
       })
       Joi.validate(layers.layers[0], schema, {presence: 'required'}).should.have.property('error', null)

--- a/test/query.js
+++ b/test/query.js
@@ -55,7 +55,6 @@ describe('Query operations', () => {
 
   it('should return only requested "outFields" set in options', () => {
     const response = FeatureServer.query(data, {outFields: 'OBJECTID'})
-
     response.fields.should.have.length(1)
     response.fields[0].should.have.property('name', 'OBJECTID')
     Object.keys(response.features[0].attributes).should.have.length(1)
@@ -403,8 +402,8 @@ describe('Query operations', () => {
 
         const response = FeatureServer.query(budgetTable, options)
         response.features[0]['attributes']['Full/Part_COUNT'].should.equal(6644)
-        response.fields[0].name.should.equal('Full/Part_COUNT')
-        response.fields[1].name.should.equal('Full/Part')
+        response.fields.findIndex(f => { return f.name === 'Full/Part_COUNT' }).should.not.equal(-1)
+        response.fields.findIndex(f => { return f.name === 'Full/Part' }).should.not.equal(-1)
       })
     })
   })

--- a/test/template.json.js
+++ b/test/template.json.js
@@ -110,7 +110,7 @@ describe('Template content', () => {
         'globalIdField': Joi.string().valid(''),
         'types': Joi.array().min(0),
         'templates': Joi.array().min(0),
-        'hasStaticData': Joi.boolean().valid(true),
+        'hasStaticData': Joi.boolean().valid(false),
         'timeInfo': Joi.object().keys({})
       })
       Joi.validate(layerJson, schema, {presence: 'required'}).should.have.property('error', null)


### PR DESCRIPTION
This new implementation supports using a provider's `idField` from metadata as the source of the OBJECTID field's value.  The field referenced by `idField` is maintained in the `fields` array of both query and layer services.  Support is removed for using a field without name or alias of 'OBJECTID' as the OBJECTID field - which produces buggy behavior in ArcGIS clients.

In addition, log warning are added when an `idField` is not set, or its key/values are potentially problematic in ArcGIS clients.