### PR TITLE
Bump winnow and adjust tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 * provider attributes referenced by metadata `idField` are maintained as separate field in addition to OBJECTID when creating ESRI json
 * warnings when a provider's `idField` is not set or references non- or out-of-range integer values
 * warning when a provider's `idField` is a mixed-case version of 'OBJECTID'
+* Bump to winnow 1.14.0
 
 ### Fixed
 * changed default value of `hasStaticData` to `false`

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lodash": "^4.12.0",
     "moment": "^2.13.0",
     "terraformer-arcgis-parser": "^1.0.4",
-    "winnow": "^1.13.0"
+    "winnow": "^1.14.0"
   },
   "devDependencies": {
     "async": "^2.5.0",

--- a/test/query.js
+++ b/test/query.js
@@ -95,7 +95,7 @@ describe('Query operations', () => {
       const response = FeatureServer.query(data, { outSR: { latestWkid: 3857 }, limit: 1, returnGeometry: true })
       response.geometryType.should.equal('esriGeometryPoint')
       response.features.length.should.equal(1)
-      response.features[0].attributes.OBJECTID.should.equal(0)
+      response.features[0].attributes.OBJECTID.should.equal(2012050174)
       response.features[0].geometry.x.should.equal(-11682713.391976157)
       response.features[0].geometry.y.should.equal(4857924.005275469)
       response.spatialReference.latestWkid.should.equal(3857)
@@ -113,21 +113,21 @@ describe('Query operations', () => {
 
   describe('when getting featureserver features by id queries', function () {
     it('should return a proper features', () => {
-      const response = FeatureServer.query(data, { objectIds: '1,2,3' })
+      const response = FeatureServer.query(data, { objectIds: '1562568434,2012050174,478725765' })
       response.should.be.an.instanceOf(Object)
       response.fields.should.be.an.instanceOf(Array)
       response.features.should.have.length(3)
     })
 
     it('should work with single id', () => {
-      const response = FeatureServer.query(data, { objectIds: 1 })
+      const response = FeatureServer.query(data, { objectIds: 1562568434 })
       response.should.be.an.instanceOf(Object)
       response.fields.should.be.an.instanceOf(Array)
       response.features.should.have.length(1)
     })
 
     it('should return only count of features', () => {
-      const response = FeatureServer.query(data, { returnCountOnly: true, objectIds: '1,2,3' })
+      const response = FeatureServer.query(data, { returnCountOnly: true, objectIds: '1562568434,2012050174,478725765' })
       response.should.be.an.instanceOf(Object)
       response.should.have.property('count')
       response.count.should.equal(3)
@@ -143,7 +143,7 @@ describe('Query operations', () => {
 
   describe('when getting features with returnIdsOnly', function () {
     it('should return only ids of features', () => {
-      const response = FeatureServer.query(data, { returnIdsOnly: true, objectIds: '1,2,3' })
+      const response = FeatureServer.query(data, { returnIdsOnly: true, objectIds: '1562568434,2012050174,478725765' })
       response.should.be.an.instanceOf(Object)
       response.should.have.property('objectIds')
       response.objectIds.length.should.equal(3)

--- a/test/route.js
+++ b/test/route.js
@@ -61,7 +61,7 @@ describe('Routing feature server requests', () => {
       request(app)
         .get('/FeatureServer/0/query?f=json&where=1%3D1')
         .expect(res => {
-          res.body.features[1].attributes.OBJECTID.should.equal(1)
+          res.body.features[1].attributes.OBJECTID.should.equal(1562568434)
           res.body.features.length.should.equal(417)
           res.body.exceededTransferLimit.should.equal(false)
         })
@@ -74,7 +74,7 @@ describe('Routing feature server requests', () => {
       request(app)
         .get('/FeatureServer/0/query?f=json&where=1%3D1')
         .expect(res => {
-          res.body.features[1].attributes.OBJECTID.should.equal(1)
+          res.body.features[1].attributes.OBJECTID.should.equal(1562568434)
           res.body.features.length.should.equal(2)
           res.body.exceededTransferLimit.should.equal(true)
         })
@@ -86,7 +86,7 @@ describe('Routing feature server requests', () => {
       request(app)
         .get('/FeatureServer/0/query?f=json&orderByFields=')
         .expect(res => {
-          res.body.features[1].attributes.OBJECTID.should.equal(1)
+          res.body.features[1].attributes.OBJECTID.should.equal(1562568434)
           res.body.features.length.should.equal(417)
         })
         .expect('Content-Type', /json/)


### PR DESCRIPTION
Bumped winnow to 1.14.0.  Since this winnow includes the switch to creation of integer hashes as OBJECTIDs, FeatureServer tests dependent on OBJECTID values had to be updated.