### PR TITLE
Problems when returnGeometry=false and outSR=<EPSG> in same request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Added
+* if request includes `returnGeometry=false` and `outSR=<EPSG>`, delete the `outSR` param since no geometry will be present to reproject
+
 ## [2.11.0] - 04-16-2018
 ### Added
 * provider attributes referenced by metadata `idField` are maintained as separate field in addition to OBJECTID when creating ESRI json

--- a/src/query.js
+++ b/src/query.js
@@ -18,7 +18,7 @@ function query (data, params = {}) {
   const options = _.cloneDeep(params)
   const hasIdField = _.has(data, 'metadata.idField')
 
-  if (filtersApplied.projection) delete options.outSR
+  if (filtersApplied.projection || options.returnGeometry === false) delete options.outSR
   if (filtersApplied.geometry) delete options.geometry
   if (filtersApplied.where || options.where === '1=1') delete options.where
   if (filtersApplied.offset) delete options.resultOffset


### PR DESCRIPTION
When `returnGeometry=false` and `outSR=<EPSG>` in same request, query results in winnow return with `attributes: undefined`.  Most likely, this is the result of  not selecting geometry when `returnGeometry=false` (see [here](https://github.com/koopjs/winnow/blob/master/src/select/index.js#L11)) and then an attempting to use missing geometry with the outSR deep inside `alasql` module.

Solution submitted here deletes `outSR` from query params when `returnGeometry=false` is also part of request.

Problem reported here: https://github.com/koopjs/FeatureServer/issues/95