### PR TITLE
Supplement/override templated rest-info json

### DIFF
--- a/src/info.js
+++ b/src/info.js
@@ -6,11 +6,11 @@ module.exports = { restInfo, serverInfo, layerInfo, layersInfo }
 
 /**
  * Pass on request for rest/info to rendering function
- * @param {object} data 
+ * @param {object} dataSourceRestInfo rest-info object that will supplement/override templated rest/info response
  * return JSON response
  */
-function restInfo (data) {
-  return renderRestInfo(data.metadata)
+function restInfo (dataSourceRestInfo) {
+  return renderRestInfo(dataSourceRestInfo)
 }
 
 function serverInfo (server, params = {}) {

--- a/src/info.js
+++ b/src/info.js
@@ -4,8 +4,13 @@ const { geometryMap } = require('./geometry')
 
 module.exports = { restInfo, serverInfo, layerInfo, layersInfo }
 
-function restInfo () {
-  return renderRestInfo()
+/**
+ * Pass on request for rest/info to rendering function
+ * @param {object} data 
+ * return JSON response
+ */
+function restInfo (data) {
+  return renderRestInfo(data.metadata)
 }
 
 function serverInfo (server, params = {}) {

--- a/src/route.js
+++ b/src/route.js
@@ -71,7 +71,7 @@ function execInfo (req, res, method, geojson) {
   const url = (req.url || req.originalUrl).split('?')[0]
   try {
     if (/\/rest\/info$/i.test(url)) {
-      info = FsInfo.restInfo()
+      info = FsInfo.restInfo(geojson)
     } else if (/\/FeatureServer$/i.test(url)) {
       info = FsInfo.serverInfo(geojson, req.params)
     } else if (/\/FeatureServer\/\d+$/i.test(url)) {

--- a/src/templates.js
+++ b/src/templates.js
@@ -89,11 +89,11 @@ function renderStatistics (featureCollection = {}, options = {}) {
 }
 
 /**
- * Get and return the templated rest/info response
+ * Get the templated rest/info response and overwrite with any provider-specific metadata
  * @param {*} restInfo
  */
-function renderRestInfo () {
-  const json = _.cloneDeep(templates.restInfo)
+function renderRestInfo (metadata = {}) {
+  const json = Object.assign(_.cloneDeep(templates.restInfo), metadata)
   return json
 }
 

--- a/src/templates.js
+++ b/src/templates.js
@@ -89,11 +89,11 @@ function renderStatistics (featureCollection = {}, options = {}) {
 }
 
 /**
- * Get the templated rest/info response and overwrite with any provider-specific metadata
- * @param {*} restInfo
+ * Get the templated rest/info response and supplement/overwrite with any provider-specific metadata
+ * @param {object} dataSourceRestInfo
  */
-function renderRestInfo (metadata = {}) {
-  const json = Object.assign(_.cloneDeep(templates.restInfo), metadata)
+function renderRestInfo (dataSourceRestInfo = {}) {
+  const json = Object.assign(_.cloneDeep(templates.restInfo), dataSourceRestInfo)
   return json
 }
 

--- a/test/info.js
+++ b/test/info.js
@@ -9,8 +9,17 @@ const Joi = require('joi')
 describe('Info operations', () => {
   describe('rest info', () => {
     it('should conform to the prescribed schema', () => {
-      const restInfo = FeatureServer.restInfo(data)
+      let supplementalRestInfo = {
+        'authInfo': {
+          'isTokenBasedSecurity': true,
+          'tokenServicesUrl': 'http://localhost/provider/generateToken'
+        }
+      }
+      const restInfo = FeatureServer.restInfo(supplementalRestInfo)
       restInfo.should.have.property('currentVersion', 10.51)
+      restInfo.should.have.property('authInfo')
+      restInfo.authInfo.should.have.property('isTokenBasedSecurity', true)
+      restInfo.authInfo.should.have.property('tokenServicesUrl').be.type('string')
     })
   })
   describe('server info', () => {


### PR DESCRIPTION
Allow metadata passed from provider to supplement/override templated `rest/info` response.