### PR TITLE
Standard update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- "6"
+- "8"
 sudo: false
 cache:
 - node_modules

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "joi": "^13.1.2",
     "mocha": "^5.0.0",
     "should": "^13.0.0",
-    "standard": "^11.0.0",
+    "standard": "^12.0.0",
     "supertest": "^3.0.0"
   },
   "standard": {

--- a/src/field/index.js
+++ b/src/field/index.js
@@ -127,7 +127,7 @@ function computeFieldsFromMetadata (metadataFields, outFieldsParam) {
   let responseFields = _.clone(metadataFields)
 
   // Add OBJECTID if it isn't already a metadata field
-  if (!_.find(metadataFields, {'name': 'OBJECTID'})) responseFields.push({name: 'OBJECTID'})
+  if (!_.find(metadataFields, { 'name': 'OBJECTID' })) responseFields.push({ name: 'OBJECTID' })
 
   // If outFields were specified and not wildcarded, create a subset of fields from metadata fields based on outFields param
   if (outFieldsParam && outFieldsParam !== '*') {

--- a/test/info.js
+++ b/test/info.js
@@ -78,7 +78,7 @@ describe('Info operations', () => {
         })),
         'tables': Joi.array()
       })
-      Joi.validate(server, schema, {presence: 'required'}).should.have.property('error', null)
+      Joi.validate(server, schema, { presence: 'required' }).should.have.property('error', null)
     })
 
     it('should work with geojson passed in', () => {
@@ -209,9 +209,9 @@ describe('Info operations', () => {
         'displayField': Joi.string(),
         'typeIdField': Joi.string().allow(null),
         'fields': Joi.array().items(Joi.object().keys({
-          'name': Joi.string().when('type', {is: 'esriFieldTypeOID', then: Joi.valid('OBJECTID'), otherwise: Joi.string()}),
+          'name': Joi.string().when('type', { is: 'esriFieldTypeOID', then: Joi.valid('OBJECTID'), otherwise: Joi.string() }),
           'type': Joi.string().allow('esriFieldTypeOID', 'esriFieldTypeInteger', 'esriFieldTypeDouble', 'esriFieldTypeString', 'esriFieldTypeDate'),
-          'alias': Joi.string().when('type', {is: 'esriFieldTypeOID', then: Joi.valid('OBJECTID'), otherwise: Joi.string()}),
+          'alias': Joi.string().when('type', { is: 'esriFieldTypeOID', then: Joi.valid('OBJECTID'), otherwise: Joi.string() }),
           'length': Joi.optional().when('type', {
             is: Joi.string().allow('esriFieldTypeString', 'esriFieldTypeDate'),
             then: Joi.number().integer().min(0)
@@ -259,7 +259,7 @@ describe('Info operations', () => {
         'hasStaticData': Joi.boolean().valid(false),
         'timeInfo': Joi.object().optional()
       })
-      Joi.validate(layers.layers[0], schema, {presence: 'required'}).should.have.property('error', null)
+      Joi.validate(layers.layers[0], schema, { presence: 'required' }).should.have.property('error', null)
       layers.layers.length.should.equal(1)
     })
   })

--- a/test/query.js
+++ b/test/query.js
@@ -31,9 +31,9 @@ describe('Query operations', () => {
         'wkid': Joi.number().integer().min(0)
       }),
       'fields': Joi.array().min(1).items(Joi.object().keys({
-        'name': Joi.string().when('type', {is: 'esriFieldTypeOID', then: Joi.valid('OBJECTID'), otherwise: Joi.string()}),
+        'name': Joi.string().when('type', { is: 'esriFieldTypeOID', then: Joi.valid('OBJECTID'), otherwise: Joi.string() }),
         'type': Joi.string().allow('esriFieldTypeOID', 'esriFieldTypeInteger', 'esriFieldTypeDouble', 'esriFieldTypeString', 'esriFieldTypeDate'),
-        'alias': Joi.string().when('type', {is: 'esriFieldTypeOID', then: Joi.valid('OBJECTID'), otherwise: Joi.string()}),
+        'alias': Joi.string().when('type', { is: 'esriFieldTypeOID', then: Joi.valid('OBJECTID'), otherwise: Joi.string() }),
         'length': Joi.optional().when('type', {
           is: Joi.string().allow('esriFieldTypeString', 'esriFieldTypeDate'),
           then: Joi.number().integer().min(0)
@@ -50,11 +50,11 @@ describe('Query operations', () => {
       })),
       'exceededTransferLimit': Joi.boolean()
     })
-    Joi.validate(response, schema, {presence: 'required'}).should.have.property('error', null)
+    Joi.validate(response, schema, { presence: 'required' }).should.have.property('error', null)
   })
 
   it('should return only requested "outFields" set in options', () => {
-    const response = FeatureServer.query(data, {outFields: 'OBJECTID'})
+    const response = FeatureServer.query(data, { outFields: 'OBJECTID' })
     response.fields.should.have.length(1)
     response.fields[0].should.have.property('name', 'OBJECTID')
     Object.keys(response.features[0].attributes).should.have.length(1)
@@ -63,7 +63,7 @@ describe('Query operations', () => {
   })
 
   it('should not return geometry data when "returnGeometry" is false', () => {
-    const response = FeatureServer.query(data, {returnGeometry: false})
+    const response = FeatureServer.query(data, { returnGeometry: false })
     response.features[0].hasOwnProperty('geometry').should.equal(false)
   })
 
@@ -95,7 +95,7 @@ describe('Query operations', () => {
       const response = FeatureServer.query(data, { outSR: { latestWkid: 3857 }, limit: 1, returnGeometry: true })
       response.geometryType.should.equal('esriGeometryPoint')
       response.features.length.should.equal(1)
-      response.features[0].attributes.OBJECTID.should.equal(2012050174)
+      response.features[0].attributes.OBJECTID.should.equal(1138516379)
       response.features[0].geometry.x.should.equal(-11682713.391976157)
       response.features[0].geometry.y.should.equal(4857924.005275469)
       response.spatialReference.latestWkid.should.equal(3857)
@@ -113,21 +113,21 @@ describe('Query operations', () => {
 
   describe('when getting featureserver features by id queries', function () {
     it('should return a proper features', () => {
-      const response = FeatureServer.query(data, { objectIds: '1562568434,2012050174,478725765' })
+      const response = FeatureServer.query(data, { objectIds: '1138516379,1954528849,578128056' })
       response.should.be.an.instanceOf(Object)
       response.fields.should.be.an.instanceOf(Array)
       response.features.should.have.length(3)
     })
 
     it('should work with single id', () => {
-      const response = FeatureServer.query(data, { objectIds: 1562568434 })
+      const response = FeatureServer.query(data, { objectIds: 1138516379 })
       response.should.be.an.instanceOf(Object)
       response.fields.should.be.an.instanceOf(Array)
       response.features.should.have.length(1)
     })
 
     it('should return only count of features', () => {
-      const response = FeatureServer.query(data, { returnCountOnly: true, objectIds: '1562568434,2012050174,478725765' })
+      const response = FeatureServer.query(data, { returnCountOnly: true, objectIds: '1138516379,1954528849,578128056' })
       response.should.be.an.instanceOf(Object)
       response.should.have.property('count')
       response.count.should.equal(3)
@@ -143,7 +143,7 @@ describe('Query operations', () => {
 
   describe('when getting features with returnIdsOnly', function () {
     it('should return only ids of features', () => {
-      const response = FeatureServer.query(data, { returnIdsOnly: true, objectIds: '1562568434,2012050174,478725765' })
+      const response = FeatureServer.query(data, { returnIdsOnly: true, objectIds: '1138516379,1954528849,578128056' })
       response.should.be.an.instanceOf(Object)
       response.should.have.property('objectIds')
       response.objectIds.length.should.equal(3)
@@ -248,7 +248,7 @@ describe('Query operations', () => {
       Object.keys(response.features[0].attributes).length.should.equal(9)
     })
 
-    it('should return correct out fields', () => {
+    it('should return correct out fields, including OBJECTID', () => {
       const options = {
         f: 'json',
         where: `"Full/Part" = 'P'`,
@@ -266,6 +266,22 @@ describe('Query operations', () => {
       response.features.length.should.equal(10)
       Object.keys(response.features[0].attributes).length.should.equal(3)
       response.features[0].hasOwnProperty('geometry').should.equal(false)
+    })
+
+    it('should return correct out fields, excluding OBJECTID', () => {
+      const options = {
+        f: 'json',
+        returnGeometry: false,
+        resultRecordCount: 1,
+        outFields: 'Name,Dept'
+      }
+
+      const response = FeatureServer.query(budgetTable, options)
+      response.fields.length.should.equal(2)
+      response.fields.find(field => field.name === 'Name').name.should.equal('Name')
+      response.fields.find(field => field.name === 'Dept').name.should.equal('Dept')
+      Object.keys(response.features[0].attributes).length.should.equal(2)
+      response.features[0].attributes.hasOwnProperty('OBJECTID').should.equal(false)
     })
   })
 
@@ -455,19 +471,19 @@ describe('Query operations', () => {
 
   describe('when an offset has already been applied', () => {
     it('should remove the result offset', () => {
-      const json = FeatureServer.query(offsetApplied, {resultOffset: 50, resultRecordCount: 1})
+      const json = FeatureServer.query(offsetApplied, { resultOffset: 50, resultRecordCount: 1 })
       json.features.length.should.be.greaterThan(0)
     })
   })
 
   describe('passing in a count', () => {
     it('should pass through a count of 0', () => {
-      const json = FeatureServer.query({count: 0}, {returnCountOnly: true})
+      const json = FeatureServer.query({ count: 0 }, { returnCountOnly: true })
       json.count.should.equal(0)
     })
 
     it('should pass through a count of 1', () => {
-      const json = FeatureServer.query({count: 1, features: [{}]}, {returnCountOnly: true})
+      const json = FeatureServer.query({ count: 1, features: [{}] }, { returnCountOnly: true })
       json.count.should.equal(1)
     })
   })

--- a/test/query.js
+++ b/test/query.js
@@ -15,8 +15,6 @@ const oneOfEach = require('./fixtures/one-of-each.json')
 const fullySpecified = require('./fixtures/fully-specified-metadata.json')
 const offsetApplied = require('./fixtures/offset-applied.json')
 
-// const moment = require('moment')
-
 describe('Query operations', () => {
   it('should return the expected response schema for an optionless query', () => {
     const response = FeatureServer.query(data, {})

--- a/test/route.js
+++ b/test/route.js
@@ -61,7 +61,7 @@ describe('Routing feature server requests', () => {
       request(app)
         .get('/FeatureServer/0/query?f=json&where=1%3D1')
         .expect(res => {
-          res.body.features[1].attributes.OBJECTID.should.equal(1562568434)
+          res.body.features[1].attributes.OBJECTID.should.equal(1954528849)
           res.body.features.length.should.equal(417)
           res.body.exceededTransferLimit.should.equal(false)
         })
@@ -74,7 +74,7 @@ describe('Routing feature server requests', () => {
       request(app)
         .get('/FeatureServer/0/query?f=json&where=1%3D1')
         .expect(res => {
-          res.body.features[1].attributes.OBJECTID.should.equal(1562568434)
+          res.body.features[1].attributes.OBJECTID.should.equal(1954528849)
           res.body.features.length.should.equal(2)
           res.body.exceededTransferLimit.should.equal(true)
         })
@@ -86,7 +86,7 @@ describe('Routing feature server requests', () => {
       request(app)
         .get('/FeatureServer/0/query?f=json&orderByFields=')
         .expect(res => {
-          res.body.features[1].attributes.OBJECTID.should.equal(1562568434)
+          res.body.features[1].attributes.OBJECTID.should.equal(1138516379)
           res.body.features.length.should.equal(417)
         })
         .expect('Content-Type', /json/)

--- a/test/template.json.js
+++ b/test/template.json.js
@@ -23,7 +23,7 @@ describe('Template content', () => {
         'features': Joi.array().max(0),
         'exceededTransferLimit': Joi.boolean().valid(false)
       })
-      Joi.validate(featuresJson, schema, {presence: 'required'}).should.have.property('error', null)
+      Joi.validate(featuresJson, schema, { presence: 'required' }).should.have.property('error', null)
     })
   })
 
@@ -38,7 +38,7 @@ describe('Template content', () => {
         'domain': Joi.valid(null),
         'defaultValue': Joi.valid(null)
       })
-      Joi.validate(fieldJson, schema, {presence: 'required'}).should.have.property('error', null)
+      Joi.validate(fieldJson, schema, { presence: 'required' }).should.have.property('error', null)
     })
   })
 
@@ -115,7 +115,7 @@ describe('Template content', () => {
         'hasStaticData': Joi.boolean().valid(false),
         'timeInfo': Joi.object().keys({})
       })
-      Joi.validate(layerJson, schema, {presence: 'required'}).should.have.property('error', null)
+      Joi.validate(layerJson, schema, { presence: 'required' }).should.have.property('error', null)
     })
   })
 
@@ -130,7 +130,7 @@ describe('Template content', () => {
         'domain': Joi.valid(null),
         'defaultValue': Joi.valid(null)
       })
-      Joi.validate(oidFieldJson, schema, {presence: 'required'}).should.have.property('error', null)
+      Joi.validate(oidFieldJson, schema, { presence: 'required' }).should.have.property('error', null)
     })
   })
 
@@ -185,7 +185,7 @@ describe('Template content', () => {
         'layers': Joi.array().min(0),
         'tables': Joi.array().min(0)
       })
-      Joi.validate(serverJson, schema, {presence: 'required'}).should.have.property('error', null)
+      Joi.validate(serverJson, schema, { presence: 'required' }).should.have.property('error', null)
     })
   })
 })


### PR DESCRIPTION
Update to standard 12 caused unexpected changes in test results; expected OBJECTIDs changed.  Possibly due to style changes regarding whitespace around object curly braces - this could conceiving change the result of the numeric hashing done to create OBJECTIDs.