### PR TITLE
Support addition of "Extract" to layer info capabilities …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Added
+* Support addition of "Extract" to layer info capabilities if provider's geojson includes `{ capabilities: { extract: true } }`
+
 ## [2.15.2] - 09-10-2018
 ### Changed
 * Supress various warnings when `NODE_ENV !== 'production'` or `KOOP_WARNINGS !== 'suppress'`

--- a/README.md
+++ b/README.md
@@ -36,6 +36,15 @@ routes.forEach(route => {
 ```
 
 ## API
+* [FeatureServer.route](#FeatureServer.route)
+* [FeatureServer.query](#FeatureServer.query)
+* [FeatureServer.serverInfo](#FeatureServer.serverInfo)
+* [FeatureServer.layerInfo](#FeatureServer.layerInfo)
+* [FeatureServer.layers](#FeatureServer.layers)
+* [FeatureServer.generateRenderer](#FeatureServer.generateRenderer)
+* [FeatureServer.authenticate](#FeatureServer.authenticate)
+* [FeatureServer.error.authorize](#FeatureServer.error.authorize)
+* [FeatureServer.authenticate](#FeatureServer.error.authenticate)
 
 ### FeatureServer.route
 Pass in an `incoming request object`, an `outgoing response object`, a `geojson` object, and `options` and this function will route and return a geoservices compliant response
@@ -144,7 +153,7 @@ FeatureServer.query(geojson, options)
 ```
 
 ### FeatureServer.serverInfo
-Generate version `10.21` Geoservices server info
+Generate version `10.51` Geoservices server info
 
 ```js
 const server = {
@@ -183,13 +192,29 @@ FeatureServer.serverInfo(server)
 ```
 
 ### FeatureServer.layerInfo
-Generate version `10.21` Geoservices information about a single layer
+Generate version `10.51` Geoservices information about a single layer
 ```js
 FeatureServer.layerInfo(geojson, options)
 ```
 
+Note that the layer info is modified with properties `metadata` and `capabilites` found at the top-level of the GeoJSON object.
+
+|GeoJSON property| Layer info result|
+|---|---|
+|`metadata.name`| overrides default|
+|`metadata.description`| overrides default |
+|`metadata.geometryType`| overrides value determined from data |
+|`metadata.extent`| overrides value determined from data |
+|`metadata.timeInfo`| overrides default |
+|`metadata.maxRecordCount`| overrides default (2000) |
+|`metadata.displayField`| overrides default (`OBJECTID`) |
+|`metadata.objectIdField`| overrides default  (`OBJECTID`) |
+|`metadata.hasStaticData`| overrides default (`false`) |
+|`capabilities.extract`|  when set to `true`, `Extract` added to `capabilites` (e.g., `capabilities: "Query,Extract"`) |
+|`capabilities.quantization`| when set to `true`, `supportsCoordinatesQuantization: true`|
+
 ### FeatureServer.layers
-Generate version `10.21` Geoservices information about one or many layers
+Generate version `10.51` Geoservices information about one or many layers
 
 Can pass a single geojson object or an array of geojson objects
 ```js
@@ -343,6 +368,7 @@ Output:
    ...
   ]
 ```
+
 ### FeatureServer.authenticate
 Pass in an outgoing response object and an authentication success object and this function will route and return a formatted authentication success response.
 

--- a/src/templates.js
+++ b/src/templates.js
@@ -56,6 +56,7 @@ function renderLayer (featureCollection = {}, options = {}) {
   if (json.displayField) json.displayField = metadata.displayField || _.get(json, 'fields[0].name') || json.displayField
   if (json.objectIdField) json.objectIdField = 'OBJECTID'
   if (capabilities.quantization) json.supportsCoordinatesQuantization = true
+  if (capabilities.extract) json.capabilities = `${json.capabilities},Extract`
   // Override the template value for hasStatic data if model metadata has this value set
   if (typeof metadata.hasStaticData === 'boolean') json.hasStaticData = metadata.hasStaticData
   return json

--- a/test/info.js
+++ b/test/info.js
@@ -368,8 +368,9 @@ describe('Info operations', () => {
   })
 
   describe('when getting featureserver info from geojson', () => {
+    const data = _.cloneDeep(polyData)
     it('should return a feature service with the proper geom type', () => {
-      const service = FeatureServer.layerInfo(polyData, {})
+      const service = FeatureServer.layerInfo(data, {})
       service.name.should.equal('map')
       service.displayField.should.equal('OBJECTID')
       service.drawingInfo.renderer.should.equal(require('../templates/renderers/symbology/polygon.json'))
@@ -378,9 +379,16 @@ describe('Info operations', () => {
     })
 
     it('should use the passed in extent if present', () => {
-      polyData.metadata.extent = [1, 2, 3, 4]
-      const service = FeatureServer.layerInfo(polyData, {})
+      data.metadata.extent = [1, 2, 3, 4]
+      const service = FeatureServer.layerInfo(data, {})
       service.extent.xmin.should.equal(1)
+    })
+
+    it('should use capabilities found in GeoJSON', () => {
+      data.capabilities = { extract: true, quantization: true}
+      const service = FeatureServer.layerInfo(data, {})
+      service.supportsCoordinatesQuantization.should.equal(true)
+      service.capabilities.should.equal('Query,Extract')
     })
   })
 

--- a/test/info.js
+++ b/test/info.js
@@ -385,7 +385,7 @@ describe('Info operations', () => {
     })
 
     it('should use capabilities found in GeoJSON', () => {
-      data.capabilities = { extract: true, quantization: true}
+      data.capabilities = { extract: true, quantization: true }
       const service = FeatureServer.layerInfo(data, {})
       service.supportsCoordinatesQuantization.should.equal(true)
       service.capabilities.should.equal('Query,Extract')


### PR DESCRIPTION
Support addition of "Extract" to layer info capabilities if provider's geojson includes `{ capabilities: { extract: true } }`.  In response to https://github.com/koopjs/FeatureServer/issues/115.