### PR TITLE
Pin travis to node 8.11.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- "8"
+- "8.11.4"
 sudo: false
 cache:
 - node_modules


### PR DESCRIPTION
Noticing that test failing on a branch due to farmhash generated object ID not getting created as expected.  Testing here to see if it has something to do with node 8.11.4 vs node 8.12.0.