### PR TITLE
Adjust value for test that was failing on Travis due to update packages.

### DIFF
--- a/test/route.js
+++ b/test/route.js
@@ -86,7 +86,7 @@ describe('Routing feature server requests', () => {
       request(app)
         .get('/FeatureServer/0/query?f=json&orderByFields=')
         .expect(res => {
-          res.body.features[1].attributes.OBJECTID.should.equal(1138516379)
+          res.body.features[1].attributes.OBJECTID.should.equal(1954528849)
           res.body.features.length.should.equal(417)
         })
         .expect('Content-Type', /json/)


### PR DESCRIPTION
Travis shows a [test failing](https://travis-ci.org/koopjs/FeatureServer/builds/436856410?utm_source=github_status&utm_medium=notification) on latest build despite no recent changes to code base.  I tested the locally and found the same behavior once I deleted `node_modules` and my local `package-lock.json` or a `yarn.lock` file. 

This likely has something to do with an update in a dependency, possibly farmhash, since we use farmhash to create OBJECTIDs, which is what the failing assertion was testing.