### PR TITLE
Add resultRecordCount to the limit setting hierarchy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Changed
+* Bump Winnow to 1.16.4
+
+### Fixed
+* Add `resultRecordCount` to the `limit` setting hierarchy
+
 ## [2.16.1] - 10-03-2018
 ### Fixed
 * package not pointed to `dist/index.js`

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lodash": "^4.12.0",
     "moment": "^2.13.0",
     "terraformer-arcgis-parser": "^1.0.4",
-    "winnow": "^1.15.3"
+    "winnow": "^1.16.4"
   },
   "devDependencies": {
     "async": "^2.5.0",

--- a/src/route.js
+++ b/src/route.js
@@ -22,16 +22,20 @@ function route (req, res, geojson, options) {
   }
 
   req.query = req.query || {}
-  req.query = coerceQuery(req.query)
   req.params = req.params || {}
   geojson = geojson || {}
   const metadata = geojson.metadata || {}
 
+  // Query parsing and coersion are now found in Koop;  TODO: Is it still needed here?
+  req.query = coerceQuery(req.query)
   Object.keys(req.query).forEach(key => {
     req.query[key] = tryParse(req.query[key])
   })
 
-  if (isNaN(req.query.limit)) req.query.limit = req.query.resultRecordCount || metadata.maxRecordCount || 2000
+  // Validate and check limit
+  if (req.query.limit && isNaN(req.query.limit)) return helpers.responseHandler(req, res, 400, { error: `Invalid "limit" parameter` })
+  else if (req.query.resultRecordCount && isNaN(req.query.resultRecordCount)) return helpers.responseHandler(req, res, 400, { error: `Invalid "resultRecordCount" parameter` })
+  if (!req.query.limit) req.query.limit = req.query.resultRecordCount || metadata.maxRecordCount || 2000
 
   // if this is for a method we can handle like query
   const method = req.params && req.params.method

--- a/src/route.js
+++ b/src/route.js
@@ -31,7 +31,7 @@ function route (req, res, geojson, options) {
     req.query[key] = tryParse(req.query[key])
   })
 
-  if (isNaN(req.query.limit)) req.query.limit = metadata.maxRecordCount || 2000
+  if (isNaN(req.query.limit)) req.query.limit = req.query.resultRecordCount || metadata.maxRecordCount || 2000
 
   // if this is for a method we can handle like query
   const method = req.params && req.params.method

--- a/test/route.js
+++ b/test/route.js
@@ -82,6 +82,28 @@ describe('Routing feature server requests', () => {
         .expect(200, done)
     })
 
+    it('should respect resultRecordCount', done => {
+      request(app)
+        .get('/FeatureServer/0/query?f=json&where=1%3D1&resultRecordCount=10')
+        .expect(res => {
+          res.body.features.length.should.equal(10)
+          res.body.exceededTransferLimit.should.equal(false)
+        })
+        .expect('Content-Type', /json/)
+        .expect(200, done)
+    })
+
+    it('should respect limit', done => {
+      request(app)
+        .get('/FeatureServer/0/query?f=json&where=1%3D1&limit=10')
+        .expect(res => {
+          res.body.features.length.should.equal(10)
+          res.body.exceededTransferLimit.should.equal(false)
+        })
+        .expect('Content-Type', /json/)
+        .expect(200, done)
+    })
+
     it('should ignore empty query parameters', done => {
       request(app)
         .get('/FeatureServer/0/query?f=json&orderByFields=')


### PR DESCRIPTION
Add validation to `limit` and `resultRecordCount` parameters.  
Add `resultRecordCount` to the `limit` setting hierarchy.
Bump Winnow.