### PR TITLE
Refactor layer-info

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,4 @@
+const _ = require('lodash')
 const esriExtent = require('esri-extent')
 const { geometryMap } = require('./geometry')
 const moment = require('moment')
@@ -6,18 +7,22 @@ const DATE_FORMATS = [moment.ISO_8601]
 module.exports = { isTable, getExtent, getGeomType, detectType, esriTypeMap }
 
 /**
- * if we have no extent, but we do have features, then it should be Table
+ * Determine if the layer is a Table
  *
- * @param {object} json
  * @param {object} data
  * @return {boolean}
  */
-function isTable (json, data) {
-  if (json.geometryType || (json.metadata && json.metadata.geometryType)) return false
-  var noExtent = !json.fullExtent || !json.fullExtent.xmin || !json.fullExtent.ymin || json.fullExtent.xmin === Infinity
-  var hasFeatures = data.features || data[0].features
-  if (noExtent && hasFeatures) return true
-  else return false
+function isTable (data) {
+  // geometry indicates this in not a table
+  const geometryType = (data.metadata && data.metadata.geometryType) || getGeomType(data)
+  if (geometryType) return false
+
+  // Check for a valid fullExtent. If unset, assume this is a Table
+  const fullExtent = data.fullExtent || (data.metadata && data.metadata.fullExtent)
+  if (_.isUndefined(fullExtent) || _.isUndefined(fullExtent.xmin) || _.isUndefined(fullExtent.ymin) || fullExtent.xmin === Infinity) return true
+
+  // Otherwise assume a feature layer
+  return false
 }
 
 function getExtent (geojson) {

--- a/templates/layer.json
+++ b/templates/layer.json
@@ -3,7 +3,6 @@
   "name": "Not Set",
   "type": "Feature Layer",
   "description": "This is a feature service powered by https://github.com/featureserver/featureserver",
-  "geometryType": "esriGeometryPoint",
   "copyrightText": " ",
   "parentLayer": null,
   "subLayers": null,

--- a/test/info.js
+++ b/test/info.js
@@ -257,7 +257,10 @@ describe('Info operations', () => {
         'types': Joi.array(),
         'templates': Joi.array(),
         'hasStaticData': Joi.boolean().valid(false),
-        'timeInfo': Joi.object().optional()
+        'timeInfo': Joi.object().optional(),
+        'spatialReference': Joi.object().keys({
+          'wkid': Joi.number().valid(4326)
+        })
       })
       Joi.validate(layers.layers[0], schema, { presence: 'required' }).should.have.property('error', null)
       layers.layers.length.should.equal(1)

--- a/test/template.json.js
+++ b/test/template.json.js
@@ -52,7 +52,6 @@ describe('Template content', () => {
         'name': Joi.string().allow(''),
         'type': Joi.string().allow('Feature Layer'),
         'description': Joi.string().allow(''),
-        'geometryType': Joi.string().valid('esriGeometryPoint', 'esriGeometryPoint', 'esriGeometryPoint'),
         'copyrightText': Joi.string().allow(''),
         'parentLayer': Joi.valid(null),
         'subLayers': Joi.valid(null),


### PR DESCRIPTION
This PR includes is a small refactor to simplify the rendering of layer info.

* Moved calculation of `extent` and the `geometryType` lookup into the `renderLayer`, as this pair were always being executed before it and then passed into `renderLayer`

* removed `geometryType` from the `layer.json` template.  This value either comes from provider metadata or is determined by feature data, so no reason to have it in the source template

* removed a series of unnecessary conditional checks in `renderLayer`;  checks were for properties on an object constructed from the `layer.json` template.  We know those properties are there - they are part of the template and under test.  No reason to check.

* refactored the `isTable` and `layersInfo` to make more readable.
