### PR TITLE
Remove `exceededTransferLimit` check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 ### Fixed
 * Before warning of discrepancies between metadata `fields` array and feature properties, compare name and alias to feature property keys.
+* Remove `exceededTransferLimit` check specific to `maxRecordCount` which can break paging functionality of clients
+
 
 ## [2.16.3] - 11-28-2018
 ### Changed

--- a/src/templates.js
+++ b/src/templates.js
@@ -74,7 +74,6 @@ function renderFeatures (data = {}, options = {}) {
   json.fields = computeFieldObject(data, 'query', options)
   json.features = data.features || []
 
-  const maxRecordCount = metadata.maxRecordCount || 2000
   if (metadata.limitExceeded) json.exceededTransferLimit = true
   if (metadata.transform) json.transform = metadata.transform
   if (metadata.idField) {

--- a/src/templates.js
+++ b/src/templates.js
@@ -75,7 +75,7 @@ function renderFeatures (data = {}, options = {}) {
   json.features = data.features || []
 
   const maxRecordCount = metadata.maxRecordCount || 2000
-  if (metadata.limitExceeded && (options.limit >= maxRecordCount)) json.exceededTransferLimit = true
+  if (metadata.limitExceeded) json.exceededTransferLimit = true
   if (metadata.transform) json.transform = metadata.transform
   if (metadata.idField) {
     json.objectIdFieldName = metadata.idField

--- a/test/route.js
+++ b/test/route.js
@@ -87,7 +87,7 @@ describe('Routing feature server requests', () => {
         .get('/FeatureServer/0/query?f=json&where=1%3D1&resultRecordCount=10')
         .expect(res => {
           res.body.features.length.should.equal(10)
-          res.body.exceededTransferLimit.should.equal(false)
+          res.body.exceededTransferLimit.should.equal(true)
         })
         .expect('Content-Type', /json/)
         .expect(200, done)
@@ -98,7 +98,7 @@ describe('Routing feature server requests', () => {
         .get('/FeatureServer/0/query?f=json&where=1%3D1&limit=10')
         .expect(res => {
           res.body.features.length.should.equal(10)
-          res.body.exceededTransferLimit.should.equal(false)
+          res.body.exceededTransferLimit.should.equal(true)
         })
         .expect('Content-Type', /json/)
         .expect(200, done)


### PR DESCRIPTION
This PR removes `(options.limit >= maxRecordCount)` from the conditional assignment of `json.exceededTransferLimit`.   After some code review, I realized this check was not necessary and can actually break paging behavior of clients.  The check is not necessary because:

1. `option.limit` is already set to `maxRecordCount` when the request doesn't arrive with a `req.query.limit` or a `req.query.resultRecordCount` (see [here](https://github.com/koopjs/FeatureServer/blob/master/src/route.js#L38)).

2. The `option.limit` is already used by the Winnow dependency to determine `limitExceeded` (see [here](https://github.com/koopjs/winnow/blob/master/src/executeQuery.js#L31-L41)). `limitExceeded` is passed back to FeatureServer and used in the check we are aiming to simplify.

3. There is no reason to check both `metadata.limitExceeded && (options.limit >= maxRecordCount)`;  if fact, doing so breaks the ability of `resultRecordCount` to properly set `exceededTransferLimit` to `true`  which can [break paging functionality of clients](https://github.com/koopjs/FeatureServer/issues/141).