### PR TITLE
Use chalk to colorize warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@mapbox/geojsonhint": "^2.1.0",
+    "chalk": "^2.4.2",
     "chroma-js": "^2.0.0",
     "classybrew": "0.0.3",
     "esri-extent": "^1.1.1",

--- a/src/field/index.js
+++ b/src/field/index.js
@@ -1,4 +1,5 @@
 const _ = require('lodash')
+const chalk = require('chalk')
 const createFieldAliases = require('./aliases')
 const createStatFields = require('./statFields')
 const { detectType, esriTypeMap } = require('../utils')
@@ -124,7 +125,7 @@ function computeFieldsFromProperties (properties, requestContext, options = {}) 
   if (options.idField) {
     hasIdField = _.find(fields, { name: options.idField })
     if (hasIdField) oidField = options.idField
-    else console.warn(`WARNING: provider's "idField" is set to ${options.idField}, but this key is not found in the GeoJSON properties`)
+    else console.warn(chalk.yellow(`WARNING: provider's "idField" is set to ${options.idField}, but this key is not found in the GeoJSON properties`))
   }
 
   // If this a layer service request and there is no set idField, add OBJECTID field if its not already a field. Decorate the with additional properties needed for layer service
@@ -153,7 +154,7 @@ function computeFieldsFromMetadata (metadataFields, options = {}) {
   let hasIdField
   if (options.idField) {
     hasIdField = _.find(metadataFields, { name: options.idField })
-    if (!hasIdField) console.warn(`WARNING: provider's "idField" is set to ${options.idField}, but this field is not defined in metadata.fields`)
+    if (!hasIdField) console.warn(chalk.yellow(`WARNING: provider's "idField" is set to ${options.idField}, but this field is not defined in metadata.fields`))
   }
 
   // If no idField and OBJECTID if it isn't already a metadata field, add it

--- a/src/query.js
+++ b/src/query.js
@@ -2,6 +2,7 @@ const Winnow = require('winnow')
 const { renderFeatures, renderStatistics, renderStats } = require('./templates')
 const Utils = require('./utils')
 const _ = require('lodash')
+const chalk = require('chalk')
 
 module.exports = query
 
@@ -35,9 +36,9 @@ function query (data, params = {}) {
   if (process.env.NODE_ENV !== 'production' && process.env.KOOP_WARNINGS !== 'suppress') {
     // ArcGIS client warnings
     if (options.toEsri && !hasIdField) {
-      console.warn(`WARNING: requested provider has no "idField" assignment. This can cause errors in ArcGIS clients`)
+      console.warn(chalk.yellow(`WARNING: requested provider has no "idField" assignment. You will get the most reliable behavior from ArcGIS clients if the provider assigns the "idField" to a property that is an unchanging 32-bit integer. Koop will create an OBJECTID field in the absence of an "idField" assignment.`))
     } else if (options.toEsri && data.metadata.idField.toLowerCase() === 'objectid' && data.metadata.idField !== 'OBJECTID') {
-      console.warn(`WARNING: requested provider's "idField" is a mixed-case version of "OBJECTID". This can cause errors in ArcGIS clients`)
+      console.warn(chalk.yellow(`WARNING: requested provider's "idField" is a mixed-case version of "OBJECTID". This can cause errors in ArcGIS clients.`))
     }
 
     // Compare provider metadata fields to feature properties
@@ -141,7 +142,7 @@ function warnOnMetadataFieldDiscrepencies (metadataFields, featureProperties) {
     // look for a defined field in the features properties
     let featureField = _.find(featureFields, ['name', field.name]) || _.find(featureFields, ['name', field.alias])
     if (!featureField || (field.type !== featureField.type && !(field.type === 'Date' && featureField.type === 'Integer') && !(field.type === 'Double' && featureField.type === 'Integer'))) {
-      console.warn(`WARNING: requested provider's metadata field "${field.name} (${field.type})" not found in feature properties)`)
+      console.warn(chalk.yellow(`WARNING: requested provider's metadata field "${field.name} (${field.type})" not found in feature properties)`))
     }
   })
 
@@ -152,7 +153,7 @@ function warnOnMetadataFieldDiscrepencies (metadataFields, featureProperties) {
 
     // Exclude warnings on feature fields named OBJECTID because OBJECTID may have been added by winnow in which case it should not be in the metadata fields array
     if (!(noNameMatch || noAliasMatch) && field.name !== 'OBJECTID') {
-      console.warn(`WARNING: requested provider's features have property "${field.name} (${field.type})" that was not defined in metadata fields array)`)
+      console.warn(chalk.yellow(`WARNING: requested provider's features have property "${field.name} (${field.type})" that was not defined in metadata fields array)`))
     }
   })
 }

--- a/src/route.js
+++ b/src/route.js
@@ -1,4 +1,5 @@
 const geojsonhint = require('@mapbox/geojsonhint')
+const chalk = require('chalk')
 const FsInfo = require('./info.js')
 const FsQuery = require('./query.js')
 const FsGenerateRenderer = require('./generateRenderer')
@@ -18,7 +19,7 @@ function route (req, res, geojson, options) {
   // Check for valid GeoJSON and warn if not found (non-production environments)
   if (process.env.NODE_ENV !== 'production' && process.env.KOOP_WARNINGS !== 'suppress') {
     let geojsonErrors = geojsonhint.hint(geojson)
-    if (geojsonErrors.length > 0) console.log(`\nWARNING: Source data for ${req.path} is invalid GeoJSON:\n ${geojsonErrors.map((err, i) => `\t ${i + 1}) ${err.message}\n`)}`)
+    if (geojsonErrors.length > 0) console.log(chalk.yellow(`WARNING: source data for ${req.path} contains invalid GeoJSON.`))
   }
 
   req.query = req.query || {}


### PR DESCRIPTION
Also:
- provider a more descriptive unassigned `idField` warning
- remove details from invalid GeoJSON warning
