### PR TITLE
Bugfix, when querying for ids only, objectIdField should be objectIdF…

### DIFF
--- a/src/query.js
+++ b/src/query.js
@@ -104,7 +104,7 @@ function geoservicesPostQuery (data, queriedData, params) {
  */
 function idsOnly (data) {
   const oidField = _.get(data, 'metadata.idField') || 'OBJECTID'
-  const response = { objectIdField: oidField, objectIds: [] }
+  const response = { objectIdFieldName: oidField, objectIds: [] }
   response.objectIds = data.features.map(f => { return f.attributes[oidField] })
   return response
 }


### PR DESCRIPTION
Bugfix, when querying for ids only, objectIdField should be objectIdFieldName, refer to ArcGIS Server FeatureServer spec at: 
[query feature service REST API](https://developers.arcgis.com/rest/services-reference/query-feature-service-.htm#ESRI_SECTION1_C03E8391A1EE4F53A0E2E12A963D0344)
and 
[query feature service layer REST API](https://developers.arcgis.com/rest/services-reference/query-feature-service-layer-.htm#ESRI_SECTION1_E56F489C853A461F9416595E2412C58E)
