### PR TITLE
Add test for objectIdFieldName in query response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Fixed
+* `returnIdsOnly=true` query requests has `objectIdFieldName` property rather than `objectIdField`
+
 ## [2.17.1] - 04-30-2019
 ### Added
 * Colorized warnings

--- a/test/query.js
+++ b/test/query.js
@@ -117,6 +117,7 @@ describe('Query operations', () => {
     it('should return only ids of features', () => {
       const response = FeatureServer.query(data, { returnIdsOnly: true, objectIds: '1138516379,1954528849,578128056' })
       response.should.be.an.instanceOf(Object)
+      response.should.have.property('objectIdFieldName', 'OBJECTID')
       response.should.have.property('objectIds')
       response.objectIds.length.should.equal(3)
     })


### PR DESCRIPTION
Query requests with param `returnIdsOnly` should return an object with the `objectIdFieldName` property and value.  This PR adds a test to confirm that behavior.