### PR TITLE
Support /FeatureServer/info route

### DIFF
--- a/src/route.js
+++ b/src/route.js
@@ -78,7 +78,7 @@ function execInfo (req, res, method, geojson) {
   try {
     if (/\/rest\/info$/i.test(url)) {
       info = FsInfo.restInfo(geojson)
-    } else if (/\/FeatureServer$/i.test(url)) {
+    } else if (/\/FeatureServer$/i.test(url) || /\/FeatureServer\/info$/i.test(url)) {
       info = FsInfo.serverInfo(geojson, req.params)
     } else if (/\/FeatureServer\/\d+$/i.test(url) || /\/FeatureServer\/\d+\/info$/i.test(url)) {
       info = FsInfo.layerInfo(geojson, req.params)

--- a/test/route.js
+++ b/test/route.js
@@ -20,6 +20,7 @@ const serverHander = (req, res) => {
 const handler = (req, res) => FeatureServer.route(req, res, data)
 
 app.get('/FeatureServer', serverHander)
+app.get('/FeatureServer/info', serverHander)
 app.get('/FeatureServer/layers', handler)
 app.get('/FeatureServer/:layer', handler)
 app.get('/FeatureServer/:layer/:method', handler)
@@ -31,9 +32,21 @@ describe('Routing feature server requests', () => {
   })
 
   describe('Server Info', () => {
-    it('should properly route and handle a server info request`', done => {
+    it('should properly route and handle a server info request to /FeatureServer`', done => {
       request(app)
         .get('/FeatureServer?f=json')
+        .expect(res => {
+          res.body.serviceDescription.should.equal('test')
+          res.body.layers.length.should.equal(2)
+          Array.isArray(res.body.tables).should.equal(true)
+        })
+        .expect('Content-Type', /json/)
+        .expect(200, done)
+    })
+
+    it('should properly route and handle a server info request to /FeatureServer/info`', done => {
+      request(app)
+        .get('/FeatureServer/info?f=json')
         .expect(res => {
           res.body.serviceDescription.should.equal('test')
           res.body.layers.length.should.equal(2)


### PR DESCRIPTION
Applies standard FeatureServer info handler to requests of form `/FeatureServer/info`.