### PR TITLE
Support info routes with trailing slashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Added
+* Support for info routes with trailing slashes
+
 ## [2.18.0] - 05-29-2019
 ### Added
 * Support for `/FeatureServer/info` requests

--- a/src/route.js
+++ b/src/route.js
@@ -78,9 +78,9 @@ function execInfo (req, res, method, geojson) {
   try {
     if (/\/rest\/info$/i.test(url)) {
       info = FsInfo.restInfo(geojson)
-    } else if (/\/FeatureServer$/i.test(url) || /\/FeatureServer\/info$/i.test(url)) {
+    } else if (/\/FeatureServer$/i.test(url) || /\/FeatureServer\/info$/i.test(url) || /\/FeatureServer\/($|\?)/.test(url)) {
       info = FsInfo.serverInfo(geojson, req.params)
-    } else if (/\/FeatureServer\/\d+$/i.test(url) || /\/FeatureServer\/\d+\/info$/i.test(url)) {
+    } else if (/\/FeatureServer\/\d+$/i.test(url) || /\/FeatureServer\/\d+\/info$/i.test(url) || /\/FeatureServer\/\d+\/($|\?)/.test(url)) {
       info = FsInfo.layerInfo(geojson, req.params)
     } else if (/\/FeatureServer\/layers$/i.test(url)) {
       info = FsInfo.layersInfo(geojson, req.query)

--- a/test/route.js
+++ b/test/route.js
@@ -44,6 +44,18 @@ describe('Routing feature server requests', () => {
         .expect(200, done)
     })
 
+    it('should properly route and handle a server info request to /FeatureServer/`', done => {
+      request(app)
+        .get('/FeatureServer/?f=json')
+        .expect(res => {
+          res.body.serviceDescription.should.equal('test')
+          res.body.layers.length.should.equal(2)
+          Array.isArray(res.body.tables).should.equal(true)
+        })
+        .expect('Content-Type', /json/)
+        .expect(200, done)
+    })
+
     it('should properly route and handle a server info request to /FeatureServer/info`', done => {
       request(app)
         .get('/FeatureServer/info?f=json')
@@ -75,6 +87,24 @@ describe('Routing feature server requests', () => {
     it('should properly route and handle a layer info request of form /FeatureServer/:layerId`', done => {
       request(app)
         .get('/FeatureServer/3?f=json')
+        .expect(res => {
+          res.body.type.should.equal('Feature Layer')
+          res.body.name.should.equal('Snow')
+          res.body.id.should.equal(3)
+          res.body.fields
+            .filter(f => {
+              return f.name === 'OBJECTID'
+            })
+            .length.should.equal(1)
+          should.exist(res.body.extent)
+        })
+        .expect('Content-Type', /json/)
+        .expect(200, done)
+    })
+
+    it('should properly route and handle a layer info request of form /FeatureServer/:layerId/`', done => {
+      request(app)
+        .get('/FeatureServer/3/?f=json')
         .expect(res => {
           res.body.type.should.equal('Feature Layer')
           res.body.name.should.equal('Snow')


### PR DESCRIPTION
Trailing slashes on  `/FeatureServer/` and `/FeatureServer/:layerId/`  lead to 400 errors; However, ArcGIS Server supports such requests and are equivalent to the same routes without the trailing slash. Some clients use such a call to determine if the resource is a feature service that supports ArcGIS REST API.

The PR adds a regex to properly route such requests.