### PR TITLE
Update templates.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+
+## [2.21.0] - 09-03-2019
+### Added
+* Support for provider to set renderer; geojson.metadata.render
+
 ## [2.20.0] - 07-02-2019
 ### Added
 * Support for `returnExtentOnly`

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ e.g.
     limitExceeded: Boolean, // whether or not the server has limited the features returned
     timeInfo: Object // describes the time extent and capabilities of the layer,
     transform: Object // describes a quantization transformation
+    renderer: Object // provider can over-ride default symbology of FeatureServer output with a renderer object. See https://developers.arcgis.com/web-map-specification/objects/simpleRenderer, for object specification.
     fields: [
      { // Subkeys are optional
        name: String,
@@ -172,6 +173,7 @@ const server = {
       maxRecordCount: Number // the maximum number of features a provider can return at once
       limitExceeded: Boolean, // whether or not the server has limited the features returned
       timeInfo: Object // describes the time extent and capabilities of the layer
+      renderer: Object // provider can over-ride default symbology of FeatureServer output with a renderer object. See https://developers.arcgis.com/web-map-specification/objects/simpleRenderer, for object specification.
     }
     features: [// If all the metadata provided above is provided features are optional.
       {
@@ -212,7 +214,7 @@ Note that the layer info is modified with properties `metadata` and `capabilites
 |`metadata.hasStaticData`| overrides default (`false`) |
 |`capabilities.extract`|  when set to `true`, `Extract` added to `capabilites` (e.g., `capabilities: "Query,Extract"`) |
 |`capabilities.quantization`| when set to `true`, `supportsCoordinatesQuantization: true`|
-
+|`metadata.renderer`| overrides default |
 ### FeatureServer.layers
 Generate version `10.51` Geoservices information about one or many layers
 

--- a/src/templates.js
+++ b/src/templates.js
@@ -39,7 +39,7 @@ function renderLayer (data = {}, options = {}) {
   json.fields = computeFieldObject(data, 'layer', options)
   json.type = isTable(data) ? 'Table' : 'Feature Layer'
   json.geometryType = getGeomType(data)
-  json.drawingInfo.renderer = renderers[json.geometryType]
+  json.drawingInfo.renderer = metadata.renderer || renderers[json.geometryType]
   json.extent = metadata.extent ? computeExtent(metadata.extent) : computeExtent(getExtent(data))
 
   if (metadata.name) json.name = metadata.name

--- a/test/fixtures/data-with-complex-metadata.json
+++ b/test/fixtures/data-with-complex-metadata.json
@@ -17,7 +17,31 @@
     "idField": "interval",
     "displayField": "label",
     "maxRecordCount": 1,
-    "hasStaticData": false
+    "hasStaticData": false,
+    "renderer": {
+      "type": "simple",
+      "symbol": {
+        "type": "esriSFS",
+        "style": "esriSFSSolid",
+        "color": [
+          115,
+          76,
+          0,
+          255
+        ],
+        "outline": {
+          "type": "esriSLS",
+          "style": "esriSLSSolid",
+          "color": [
+            110,
+            110,
+            110,
+            255
+          ],
+          "width": 1
+        }
+      }
+    }
   },
   "capabilities": {
     "quantization": true,

--- a/test/info.js
+++ b/test/info.js
@@ -229,6 +229,16 @@ describe('Info operations', () => {
 
       Joi.validate(layers.layers[0], layersSchemaOverride, { presence: 'required' }).should.have.property('error', null)
       layers.layers.length.should.equal(1)
+      //from the complex-metadata fixture and not defaults
+      layers.layers[0].drawingInfo.renderer.symbol.color[0].should.equal(115)
+      layers.layers[0].drawingInfo.renderer.symbol.color[1].should.equal(76)
+      layers.layers[0].drawingInfo.renderer.symbol.color[2].should.equal(0)
+      layers.layers[0].drawingInfo.renderer.symbol.color[3].should.equal(255)
+      layers.layers[0].drawingInfo.renderer.symbol.outline.color[0].should.equal(110)
+      layers.layers[0].drawingInfo.renderer.symbol.outline.color[1].should.equal(110)
+      layers.layers[0].drawingInfo.renderer.symbol.outline.color[2].should.equal(110)
+      layers.layers[0].drawingInfo.renderer.symbol.outline.color[3].should.equal(255)
+      layers.layers[0].drawingInfo.renderer.symbol.outline.width.should.equal(1)
     })
   })
 

--- a/test/info.js
+++ b/test/info.js
@@ -228,8 +228,8 @@ describe('Info operations', () => {
       })
 
       Joi.validate(layers.layers[0], layersSchemaOverride, { presence: 'required' }).should.have.property('error', null)
+      
       layers.layers.length.should.equal(1)
-      //from the complex-metadata fixture and not defaults
       layers.layers[0].drawingInfo.renderer.symbol.color[0].should.equal(115)
       layers.layers[0].drawingInfo.renderer.symbol.color[1].should.equal(76)
       layers.layers[0].drawingInfo.renderer.symbol.color[2].should.equal(0)

--- a/test/info.js
+++ b/test/info.js
@@ -228,7 +228,6 @@ describe('Info operations', () => {
       })
 
       Joi.validate(layers.layers[0], layersSchemaOverride, { presence: 'required' }).should.have.property('error', null)
-      
       layers.layers.length.should.equal(1)
       layers.layers[0].drawingInfo.renderer.symbol.color[0].should.equal(115)
       layers.layers[0].drawingInfo.renderer.symbol.color[1].should.equal(76)


### PR DESCRIPTION
added check for metadata.renderer to allow a koop provider to provide symbology for feature server route.

This should satisfy issue #80 and maybe #65 but, #65 might be asking for more than this.