### PR TITLE
Fix moving object id field to start.

### DIFF
--- a/src/field/index.js
+++ b/src/field/index.js
@@ -50,7 +50,10 @@ function computeFieldsCollection (data, requestContext, options = {}) {
   })
 
   // Ensure the OBJECTID field is first in the array
-  responsefields.unshift(responsefields.splice(responsefields.findIndex(field => field.name === 'OBJECTID'), 1)[0])
+  const idFieldIndex = responsefields.findIndex(field => field.type === templates.objectIDField.type);
+  if (idFieldIndex !== -1) {
+    responsefields.unshift(responsefields.splice(idFieldIndex, 1)[0])
+  }
 
   return responsefields
 }

--- a/src/field/index.js
+++ b/src/field/index.js
@@ -50,7 +50,7 @@ function computeFieldsCollection (data, requestContext, options = {}) {
   })
 
   // Ensure the OBJECTID field is first in the array
-  const idFieldIndex = responsefields.findIndex(field => field.type === templates.objectIDField.type);
+  const idFieldIndex = responsefields.findIndex(field => field.type === templates.objectIDField.type)
   if (idFieldIndex !== -1) {
     responsefields.unshift(responsefields.splice(idFieldIndex, 1)[0])
   }


### PR DESCRIPTION
If the object id field was named anything other than OBJECTID it
was not being moved to the start of the response fields (instead
the last field was being moved to the start). Fixed to pick out
the object id based on field type.