### PR TITLE
Allow Editable Fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Changed
+* Added ability to specify the editable property for each field via the metadata object
+
 ## [3.0.1] - 09-01-2021
 ### Changed
 * Added ability to specify capabilities the feature service would like to handle

--- a/lib/field/index.js
+++ b/lib/field/index.js
@@ -47,6 +47,7 @@ function computeFieldsCollection (data, requestContext, options = {}) {
       context: requestContext,
       idField: metadata.idField,
       domain: field.domain,
+      editable: field.editable,
       nullable: field.nullable
     })
   })
@@ -67,7 +68,7 @@ function computeFieldsCollection (data, requestContext, options = {}) {
  */
 function computeFieldObject (name, options = {}) {
   let outputField
-  const { alias = name, type = 'string', length, context, idField, domain, nullable } = options
+  const { alias = name, type = 'string', length, context, idField, domain, editable = false, nullable } = options
 
   // Identify objectIdField with the name that matches the metadata idField or the default name "OBJECTID"
   if (name === idField || name === 'OBJECTID') {
@@ -93,7 +94,7 @@ function computeFieldObject (name, options = {}) {
   // Layer service field objects have addition 'editable' and 'nullable' properties
   if (context === 'layer') {
     Object.assign(outputField, {
-      editable: false,
+      editable: editable,
       domain: domain || null,
       nullable: typeof nullable !== 'undefined' ? nullable : false
     })

--- a/test/integration/info.spec.js
+++ b/test/integration/info.spec.js
@@ -378,6 +378,24 @@ describe('Info operations', () => {
       layer.fields.find(f => { return f.name === 'test' }).length.should.equal(1000)
     })
 
+    it('should assign editable from metadata', () => {
+      const input = {
+        metadata: {
+          geometryType: 'Polygon',
+          extent: [[11, 12], [13, 14]],
+          fields: [
+            {
+              name: 'test',
+              type: 'String',
+              editable: true
+            }
+          ]
+        }
+      }
+      const layer = FeatureServer.layerInfo(input, {})
+      layer.fields.find(f => { return f.name === 'test' }).editable.should.equal(true)
+    })
+
     it('should support a metadata with layer id, defaultVisibility, minScale, and maxScale values', () => {
       const input = _.cloneDeep(data)
       input.metadata = {

--- a/test/integration/schemas/index.js
+++ b/test/integration/schemas/index.js
@@ -104,7 +104,7 @@ const layersTemplateSchema = Joi.object().keys({
     }),
     defaultValue: Joi.any().valid(null),
     domain: Joi.any().valid(null),
-    editable: Joi.boolean().valid(false),
+    editable: Joi.boolean().valid(false, true),
     nullable: Joi.boolean().valid(false),
     sqlType: Joi.string().valid('sqlTypeOther', 'sqlTypeDouble', 'sqlTypeInteger')
   })).min(0),


### PR DESCRIPTION
By specifying editable as true in field metadata the resulting feature service will advertise the fields as editable.