### PR TITLE
Correctly set table ids when service has layers and tables

### DIFF
--- a/lib/server-info-route-handler.js
+++ b/lib/server-info-route-handler.js
@@ -24,7 +24,9 @@ function serverMetadata (json, { query = {} } = {}) {
     fullExtent,
     initialExtent: fullExtent,
     layers: layers.map(layerInfo),
-    tables: tables.map(tableInfo),
+    tables: tables.map((json, idx) => {
+      return tableInfo(json, layers.length + idx)
+    }),
     serviceDescription: description,
     maxRecordCount: maxRecordCount || _.get(layers, '[0].metadata.maxRecordCount'),
     hasStaticData: typeof hasStaticData === 'boolean' ? hasStaticData : false

--- a/test/unit/server-info-route-handler.spec.js
+++ b/test/unit/server-info-route-handler.spec.js
@@ -358,8 +358,8 @@ describe('server info', () => {
         geometryType: 'esriGeometryPoint'
       }],
       tables: [{
-        id: 0,
-        name: 'Table_0',
+        id: 2,
+        name: 'Table_2',
         parentLayerId: -1,
         defaultVisibility: true,
         subLayerIds: null,


### PR DESCRIPTION
Table id's are currently starting at 0 even if there are layers present. Table ids should start n+1 from last layer id.