### PR TITLE
Minor changes in advance of bigger refactor PR.

### DIFF
--- a/lib/generateRenderer/createClassificationInfos.js
+++ b/lib/generateRenderer/createClassificationInfos.js
@@ -27,8 +27,8 @@ function createUniqueValueInfos (breaks, classification, geomType) {
   const { colorRamp, baseSymbol } = setSymbology(breaks, classification)
 
   // check that unique value fields are congruous
-  if (!classification.uniqueValueFields.map(field => {
-    Object.keys(breaks[0]).includes(field)
+  if (classification.uniqueValueFields.some(field => {
+    return !Object.keys(breaks[0]).includes(field)
   })) {
     throw new Error(
       'Unique value fields are incongruous: ' +

--- a/lib/generateRenderer/getGeom.js
+++ b/lib/generateRenderer/getGeom.js
@@ -12,8 +12,10 @@ function getGeom (data, params) {
 
 function getDataGeom (data) {
   const type = data.features[0].geometry.type
-  data.features.map(feature => {
-    if (feature.geometry.type !== type) throw new Error('Geometry types are not consistent')
+  data.features.forEach(feature => {
+    if (feature.geometry.type !== type) {
+      throw new Error('Geometry types are not consistent')
+    }
   })
   if (type !== 'Point' && type !== 'Line' && type !== 'Polygon') {
     throw new Error('Unrecognized geometry type: ' + type)

--- a/lib/query/filter-and-transform.js
+++ b/lib/query/filter-and-transform.js
@@ -3,6 +3,7 @@ const { query } = require('winnow')
 const helpers = require('../helpers')
 
 function filterAndTransform (json, requestParams) {
+  const { features, type, ...restJson } = json
   const params = FilterAndTransformParams.create(requestParams)
     .removeParamsAlreadyApplied(json.filtersApplied)
     .addToEsri()
@@ -11,10 +12,16 @@ function filterAndTransform (json, requestParams) {
 
   const result = query(json, params)
 
-  const { objectIds } = params
-  const { outStatistics } = result
+  const { objectIds, outStatistics } = params
 
-  if (!shouldFilterByObjectIds(objectIds, outStatistics)) {
+  if (outStatistics) {
+    return {
+      statistics: result,
+      ...restJson
+    }
+  }
+
+  if (!objectIds) {
     return result
   }
 
@@ -93,11 +100,6 @@ class FilterAndTransformParams {
 
     return this
   }
-}
-
-function shouldFilterByObjectIds (objectIds, outStatistics) {
-  // request for objectIds ignored if out-statistics option is also requested
-  return objectIds && !outStatistics
 }
 
 function filterByObjectIds (data, objectIds) {

--- a/lib/query/index.js
+++ b/lib/query/index.js
@@ -61,11 +61,16 @@ function shouldRenderPrecalculatedData ({ statistics, count, extent }, { returnC
   return false
 }
 
-function renderPrecalculatedData (data, { returnCountOnly, returnExtentOnly }) {
+function renderPrecalculatedData (data, {
+  returnCountOnly,
+  returnExtentOnly,
+  outStatistics,
+  groupByFieldsForStatistics
+}) {
   const { statistics, count, extent } = data
 
   if (statistics) {
-    return renderPrecalculatedStatisticsResponse(data)
+    return renderPrecalculatedStatisticsResponse(data, { outStatistics, groupByFieldsForStatistics })
   }
 
   const retVal = {}
@@ -87,7 +92,6 @@ function shouldLogWarnings () {
 
 function renderGeoservicesResponse (data, params = {}) {
   const {
-    outStatistics,
     returnCountOnly,
     returnExtentOnly,
     returnIdsOnly,
@@ -106,7 +110,7 @@ function renderGeoservicesResponse (data, params = {}) {
     return renderIdsOnlyResponse(data)
   }
 
-  if (outStatistics) {
+  if (data.statistics) {
     return renderStatisticsResponse(data, params)
   }
 

--- a/lib/query/log-warnings.js
+++ b/lib/query/log-warnings.js
@@ -42,7 +42,7 @@ function warnOnMetadataFieldDiscrepancies (metadataFields, featureProperties) {
 
   // compare metadata to feature properties; identifies fields defined in metadata that are not found in feature properties
   // or that have a metadata type definition inconsistent with feature property's value
-  metadataFields.filter(field => {
+  metadataFields.forEach(field => {
     // look for a defined field in the features properties
     const featureField = _.find(featureFields, ['name', field.name]) || _.find(featureFields, ['name', field.alias])
     if (!featureField || (field.type !== featureField.type && !(field.type === 'Date' && featureField.type === 'Integer') && !(field.type === 'Double' && featureField.type === 'Integer'))) {
@@ -51,7 +51,7 @@ function warnOnMetadataFieldDiscrepancies (metadataFields, featureProperties) {
   })
 
   // compare feature properties to metadata fields; identifies fields found on feature that are not defined in metadata field array
-  featureFields.filter(field => {
+  featureFields.forEach(field => {
     const noNameMatch = _.find(metadataFields, ['name', field.name])
     const noAliasMatch = _.find(metadataFields, ['alias', field.name])
 

--- a/lib/query/render-statistics.js
+++ b/lib/query/render-statistics.js
@@ -1,8 +1,9 @@
 const { computeFieldObject } = require('../field')
 
 function renderStatisticsResponse (input = {}, options = {}) {
-  const statistics = Array.isArray(input) ? input : [input]
-  const features = statistics.map(attributes => {
+  const { statistics } = input
+  const normalizedStatistics = Array.isArray(statistics) ? statistics : [statistics]
+  const features = normalizedStatistics.map(attributes => {
     return { attributes }
   })
 

--- a/test/unit/query/filter-and-transform.spec.js
+++ b/test/unit/query/filter-and-transform.spec.js
@@ -13,7 +13,7 @@ describe('filterAndTransform', () => {
     const getCollectionCrsSpy = sinon.spy(function () {})
 
     const filterAndTransformSpy = sinon.spy(function () {
-      return 'expected-result'
+      return { features: 'expected-result' }
     })
 
     const stub = {
@@ -33,7 +33,9 @@ describe('filterAndTransform', () => {
     describe('should set toEsri:false and pass to filter/transform', () => {
       it('should set toEsri:false when requested format is geojson', () => {
         const result = filterAndTransform({ features: [{}] }, { f: 'geojson' })
-        result.should.deepEqual('expected-result')
+        result.should.deepEqual({
+          features: 'expected-result'
+        })
         filterAndTransformSpy.callCount.should.equal(1)
         filterAndTransformSpy.firstCall.args.should.deepEqual([
           { features: [{}] },
@@ -46,7 +48,9 @@ describe('filterAndTransform', () => {
           { features: [{}] },
           { returnExtentOnly: true }
         )
-        result.should.deepEqual('expected-result')
+        result.should.deepEqual({
+          features: 'expected-result'
+        })
         filterAndTransformSpy.callCount.should.equal(1)
         filterAndTransformSpy.firstCall.args.should.deepEqual([
           { features: [{}] },
@@ -58,7 +62,9 @@ describe('filterAndTransform', () => {
     describe('should properly set inputCrs and pass to filter/transform', () => {
       it('should get value from default', () => {
         const result = filterAndTransform({ features: [{}] }, {})
-        result.should.deepEqual('expected-result')
+        result.should.deepEqual({
+          features: 'expected-result'
+        })
         filterAndTransformSpy.callCount.should.equal(1)
         filterAndTransformSpy.firstCall.args.should.deepEqual([
           { features: [{}] },
@@ -84,7 +90,9 @@ describe('filterAndTransform', () => {
           stub
         )
         const result = filterAndTransform({ features: [{}] }, {})
-        result.should.deepEqual('expected-result')
+        result.should.deepEqual({
+          features: 'expected-result'
+        })
         filterAndTransformSpy.callCount.should.equal(1)
         filterAndTransformSpy.firstCall.args.should.deepEqual([
           { features: [{}] },
@@ -97,7 +105,9 @@ describe('filterAndTransform', () => {
           { metadata: { crs: 1234 }, features: [{}] },
           {}
         )
-        result.should.deepEqual('expected-result')
+        result.should.deepEqual({
+          features: 'expected-result'
+        })
         filterAndTransformSpy.callCount.should.equal(1)
         filterAndTransformSpy.firstCall.args.should.deepEqual([
           { metadata: { crs: 1234 }, features: [{}] },
@@ -110,7 +120,9 @@ describe('filterAndTransform', () => {
           { metadata: { crs: 1234 }, features: [{}] },
           { sourceSR: 4229 }
         )
-        result.should.deepEqual('expected-result')
+        result.should.deepEqual({
+          features: 'expected-result'
+        })
         filterAndTransformSpy.callCount.should.equal(1)
         filterAndTransformSpy.firstCall.args.should.deepEqual([
           { metadata: { crs: 1234 }, features: [{}] },
@@ -123,7 +135,9 @@ describe('filterAndTransform', () => {
           { metadata: { crs: 1234 }, features: [{}] },
           { sourceSR: 4229, inputCrs: 4673 }
         )
-        result.should.deepEqual('expected-result')
+        result.should.deepEqual({
+          features: 'expected-result'
+        })
         filterAndTransformSpy.callCount.should.equal(1)
         filterAndTransformSpy.firstCall.args.should.deepEqual([
           { metadata: { crs: 1234 }, features: [{}] },
@@ -152,7 +166,9 @@ describe('filterAndTransform', () => {
         limit: 10,
         resultRecordOffset: 20
       })
-      result.should.deepEqual('expected-result')
+      result.should.deepEqual({
+        features: 'expected-result'
+      })
       filterAndTransformSpy.callCount.should.equal(1)
       filterAndTransformSpy.firstCall.args.should.deepEqual([
         json,
@@ -377,6 +393,70 @@ describe('filterAndTransform', () => {
           ]
         },
         { inputCrs: 4326, toEsri: true, objectIds: ['a'] }
+      ])
+    })
+  })
+
+  describe('should filter by objectIds', () => {
+    afterEach(function () {
+      filterAndTransformSpy.resetHistory()
+      getCollectionCrsSpy.resetHistory()
+    })
+    const getCollectionCrsSpy = sinon.spy(function () {})
+
+    const filterAndTransformSpy = sinon.spy(function () {
+      return {
+        min_precip: 10
+      }
+    })
+
+    const stub = {
+      '../helpers': {
+        getCollectionCrs: getCollectionCrsSpy
+      },
+      winnow: {
+        query: filterAndTransformSpy
+      }
+    }
+
+    const { filterAndTransform } = proxyquire(
+      '../../../lib/query/filter-and-transform',
+      stub
+    )
+
+    it('should wrap statistics results and add in metadata', () => {
+      const result = filterAndTransform(
+        {
+          features: [
+            { properties: { precip: 10 } },
+            { properties: { precip: 20 } },
+            { properties: { precip: 30 } }
+          ],
+          metadata: {
+            foo: 'bar'
+          }
+        },
+        { outStatistics: [] }
+      )
+      result.should.deepEqual({
+        statistics: { min_precip: 10 },
+        metadata: {
+          foo: 'bar'
+        }
+      })
+      filterAndTransformSpy.callCount.should.equal(1)
+      filterAndTransformSpy.firstCall.args.should.deepEqual([
+        {
+          features: [
+            { properties: { precip: 10 } },
+            { properties: { precip: 20 } },
+            { properties: { precip: 30 } }
+          ],
+          metadata: {
+            foo: 'bar'
+          }
+        },
+        { inputCrs: 4326, toEsri: true, outStatistics: [] }
       ])
     })
   })

--- a/test/unit/query/render-statistics.spec.js
+++ b/test/unit/query/render-statistics.spec.js
@@ -22,7 +22,7 @@ describe('renderStatisticsResponse', () => {
   })
 
   it('should convert statistics array to Geoservices JSON', () => {
-    const result = renderStatisticsResponse([{ min_precip: 0 }], {
+    const result = renderStatisticsResponse({ statistics: [{ min_precip: 0 }] }, {
       outStatistics: [{
         statisticType: 'MIN',
         onStatisticField: 'total precip',
@@ -57,7 +57,7 @@ describe('renderStatisticsResponse', () => {
   })
 
   it('should convert statistics object to Geoservices JSON', () => {
-    const result = renderStatisticsResponse({ min_precip: 0 }, {
+    const result = renderStatisticsResponse({ statistics: { min_precip: 0 } }, {
       outStatistics: [{
         statisticType: 'MIN',
         onStatisticField: 'total precip',


### PR DESCRIPTION
This PR makes some minor changes/improvements that were done as part of a bigger effort to refactor the way the `fields` array is generated on layer info and query routes.  The changes here are independent of that refactor, thus separating them out to reduce file count and scope of upcoming PR. Changes include:

- swapping poorly chosen array methods identified by linter; e.g., a `.filter` which really should be a `.forEach`.
- proper handling/wrapping of statistics aggregations from winnow