### PR TITLE
New fields generation files and tests.

### DIFF
--- a/lib/helpers/fields/constants.js
+++ b/lib/helpers/fields/constants.js
@@ -1,0 +1,10 @@
+module.exports = {
+  ESRI_FIELD_TYPE_OID: 'esriFieldTypeOID',
+  ESRI_FIELD_TYPE_STRING: 'esriFieldTypeString',
+  ESRI_FIELD_TYPE_DATE: 'esriFieldTypeDate',
+  ESRI_FIELD_TYPE_DOUBLE: 'esriFieldTypeDouble',
+  SQL_TYPE_INTEGER: 'sqlTypeInteger',
+  SQL_TYPE_OTHER: 'sqlTypeOther',
+  SQL_TYPE_FLOAT: 'sqlTypeFloat',
+  OBJECTID_DEFAULT_KEY: 'OBJECTID'
+}

--- a/lib/helpers/fields/data-type-utils.js
+++ b/lib/helpers/fields/data-type-utils.js
@@ -1,10 +1,11 @@
+const _ = require('lodash')
 const {
   isValidISODateString,
   isValidDate
 } = require('iso-datestring-validator')
 
 function getDataTypeFromValue (value) {
-  if (typeof value === 'number') {
+  if (_.isNumber(value)) {
     return Number.isInteger(value) ? 'Integer' : 'Double'
   }
 

--- a/lib/helpers/fields/data-type-utils.js
+++ b/lib/helpers/fields/data-type-utils.js
@@ -1,0 +1,25 @@
+const {
+  isValidISODateString,
+  isValidDate
+} = require('iso-datestring-validator')
+
+function getDataTypeFromValue (value) {
+  if (typeof value === 'number') {
+    return Number.isInteger(value) ? 'Integer' : 'Double'
+  }
+
+  if (isDate(value)) {
+    return 'Date'
+  }
+
+  return 'String'
+}
+
+function isDate (value) {
+  return value instanceof Date || ((typeof value === 'string') && (isValidDate(value) || isValidISODateString(value)))
+}
+
+module.exports = {
+  getDataTypeFromValue,
+  isDate
+}

--- a/lib/helpers/fields/esri-type-utils.js
+++ b/lib/helpers/fields/esri-type-utils.js
@@ -1,13 +1,18 @@
 const { getDataTypeFromValue } = require('./data-type-utils')
+const {
+  ESRI_FIELD_TYPE_STRING,
+  ESRI_FIELD_TYPE_DATE,
+  ESRI_FIELD_TYPE_DOUBLE,
+} = require('./constants')
 
 function getEsriTypeFromDefinition (typeDefinition = '') {
   switch (typeDefinition.toLowerCase()) {
     case 'double':
-      return 'esriFieldTypeDouble'
+      return ESRI_FIELD_TYPE_DOUBLE
     case 'integer':
       return 'esriFieldTypeInteger'
     case 'date':
-      return 'esriFieldTypeDate'
+      return ESRI_FIELD_TYPE_DATE
     case 'blob':
       return 'esriFieldTypeBlob'
     case 'geometry':
@@ -26,7 +31,7 @@ function getEsriTypeFromDefinition (typeDefinition = '') {
       return 'esriFieldTypeXML'
     case 'string':
     default:
-      return 'esriFieldTypeString'
+      return ESRI_FIELD_TYPE_STRING
   }
 }
 

--- a/lib/helpers/fields/esri-type-utils.js
+++ b/lib/helpers/fields/esri-type-utils.js
@@ -2,7 +2,7 @@ const { getDataTypeFromValue } = require('./data-type-utils')
 const {
   ESRI_FIELD_TYPE_STRING,
   ESRI_FIELD_TYPE_DATE,
-  ESRI_FIELD_TYPE_DOUBLE,
+  ESRI_FIELD_TYPE_DOUBLE
 } = require('./constants')
 
 function getEsriTypeFromDefinition (typeDefinition = '') {

--- a/lib/helpers/fields/esri-type-utils.js
+++ b/lib/helpers/fields/esri-type-utils.js
@@ -1,0 +1,42 @@
+const { getDataTypeFromValue } = require('./data-type-utils')
+
+function getEsriTypeFromDefinition (typeDefinition = '') {
+  switch (typeDefinition.toLowerCase()) {
+    case 'double':
+      return 'esriFieldTypeDouble'
+    case 'integer':
+      return 'esriFieldTypeInteger'
+    case 'date':
+      return 'esriFieldTypeDate'
+    case 'blob':
+      return 'esriFieldTypeBlob'
+    case 'geometry':
+      return 'esriFieldTypeGeometry'
+    case 'globalid':
+      return 'esriFieldTypeGlobalID'
+    case 'guid':
+      return 'esriFieldTypeGUID'
+    case 'raster':
+      return 'esriFieldTypeRaster'
+    case 'single':
+      return 'esriFieldTypeSingle'
+    case 'smallinteger':
+      return 'esriFieldTypeSmallInteger'
+    case 'xml':
+      return 'esriFieldTypeXML'
+    case 'string':
+    default:
+      return 'esriFieldTypeString'
+  }
+}
+
+function getEsriTypeFromValue (value) {
+  const dataType = getDataTypeFromValue(value)
+
+  return getEsriTypeFromDefinition(dataType)
+}
+
+module.exports = {
+  getEsriTypeFromDefinition,
+  getEsriTypeFromValue
+}

--- a/lib/helpers/fields/field-classes.js
+++ b/lib/helpers/fields/field-classes.js
@@ -2,6 +2,16 @@ const {
   getEsriTypeFromDefinition,
   getEsriTypeFromValue
 } = require('./esri-type-utils')
+const {
+  ESRI_FIELD_TYPE_OID,
+  ESRI_FIELD_TYPE_STRING,
+  ESRI_FIELD_TYPE_DATE,
+  ESRI_FIELD_TYPE_DOUBLE,
+  SQL_TYPE_INTEGER,
+  SQL_TYPE_OTHER,
+  SQL_TYPE_FLOAT,
+  OBJECTID_DEFAULT_KEY
+} = require('./constants')
 
 class Field {
   setEditable (value = false) {
@@ -15,21 +25,21 @@ class Field {
   }
 
   setLength () {
-    if (this.type === 'esriFieldTypeString') {
+    if (this.type === ESRI_FIELD_TYPE_STRING) {
       this.length = 128
-    } else if (this.type === 'esriFieldTypeDate') {
+    } else if (this.type === ESRI_FIELD_TYPE_DATE) {
       this.length = 36
     }
   }
 }
 
 class ObjectIdField extends Field {
-  constructor (key = 'OBJECTID') {
+  constructor (key = OBJECTID_DEFAULT_KEY) {
     super()
     this.name = key
-    this.type = 'esriFieldTypeOID'
+    this.type = ESRI_FIELD_TYPE_OID
     this.alias = key
-    this.sqlType = 'sqlTypeInteger'
+    this.sqlType = SQL_TYPE_INTEGER
     this.domain = null
     this.defaultValue = null
   }
@@ -41,7 +51,7 @@ class FieldFromKeyValue extends Field {
     this.name = key
     this.type = getEsriTypeFromValue(value)
     this.alias = key
-    this.sqlType = 'sqlTypeOther'
+    this.sqlType = SQL_TYPE_OTHER
     this.domain = null
     this.defaultValue = null
     this.setLength()
@@ -52,8 +62,8 @@ class StatisticField extends Field {
   constructor (key) {
     super()
     this.name = key
-    this.type = 'esriFieldTypeDouble'
-    this.sqlType = 'sqlTypeFloat'
+    this.type = ESRI_FIELD_TYPE_DOUBLE
+    this.sqlType = SQL_TYPE_FLOAT
     this.alias = key
     this.domain = null
     this.defaultValue = null
@@ -63,8 +73,8 @@ class StatisticField extends Field {
 class StatisticDateField extends StatisticField {
   constructor (key) {
     super(key)
-    this.type = 'esriFieldTypeDate'
-    this.sqlType = 'sqlTypeOther'
+    this.type = ESRI_FIELD_TYPE_DATE
+    this.sqlType = SQL_TYPE_OTHER
   }
 }
 
@@ -84,7 +94,7 @@ class FieldFromFieldDefinition extends Field {
     this.name = name
     this.type = getEsriTypeFromDefinition(type)
     this.alias = alias || name
-    this.sqlType = sqlType || 'sqlTypeOther'
+    this.sqlType = sqlType || SQL_TYPE_OTHER
     this.domain = domain || null
     this.defaultValue = defaultValue || null
     this.length = length
@@ -98,8 +108,8 @@ class FieldFromFieldDefinition extends Field {
 class ObjectIdFieldFromDefinition extends FieldFromFieldDefinition {
   constructor (definition = {}) {
     super(definition)
-    this.type = 'esriFieldTypeOID'
-    this.sqlType = 'sqlTypeInteger'
+    this.type = ESRI_FIELD_TYPE_OID
+    this.sqlType = SQL_TYPE_INTEGER
     delete this.length
   }
 }

--- a/lib/helpers/fields/field-classes.js
+++ b/lib/helpers/fields/field-classes.js
@@ -1,0 +1,114 @@
+const {
+  getEsriTypeFromDefinition,
+  getEsriTypeFromValue
+} = require('./esri-type-utils')
+
+class Field {
+  setEditable (value = false) {
+    this.editable = value
+    return this
+  }
+
+  setNullable (value = false) {
+    this.nullable = value
+    return this
+  }
+
+  setLength () {
+    if (this.type === 'esriFieldTypeString') {
+      this.length = 128
+    } else if (this.type === 'esriFieldTypeDate') {
+      this.length = 36
+    }
+  }
+}
+
+class ObjectIdField extends Field {
+  constructor (key = 'OBJECTID') {
+    super()
+    this.name = key
+    this.type = 'esriFieldTypeOID'
+    this.alias = key
+    this.sqlType = 'sqlTypeInteger'
+    this.domain = null
+    this.defaultValue = null
+  }
+}
+
+class FieldFromKeyValue extends Field {
+  constructor (key, value) {
+    super()
+    this.name = key
+    this.type = getEsriTypeFromValue(value)
+    this.alias = key
+    this.sqlType = 'sqlTypeOther'
+    this.domain = null
+    this.defaultValue = null
+    this.setLength()
+  }
+}
+
+class StatisticField extends Field {
+  constructor (key) {
+    super()
+    this.name = key
+    this.type = 'esriFieldTypeDouble'
+    this.sqlType = 'sqlTypeFloat'
+    this.alias = key
+    this.domain = null
+    this.defaultValue = null
+  }
+}
+
+class StatisticDateField extends StatisticField {
+  constructor (key) {
+    super(key)
+    this.type = 'esriFieldTypeDate'
+    this.sqlType = 'sqlTypeOther'
+  }
+}
+
+class FieldFromFieldDefinition extends Field {
+  constructor (fieldDefinition) {
+    super()
+    const {
+      name,
+      type,
+      alias,
+      domain,
+      sqlType,
+      length,
+      defaultValue
+    } = fieldDefinition
+
+    this.name = name
+    this.type = getEsriTypeFromDefinition(type)
+    this.alias = alias || name
+    this.sqlType = sqlType || 'sqlTypeOther'
+    this.domain = domain || null
+    this.defaultValue = defaultValue || null
+    this.length = length
+
+    if (!this.length || !Number.isInteger(this.length)) {
+      this.setLength()
+    }
+  }
+}
+
+class ObjectIdFieldFromDefinition extends FieldFromFieldDefinition {
+  constructor (definition = {}) {
+    super(definition)
+    this.type = 'esriFieldTypeOID'
+    this.sqlType = 'sqlTypeInteger'
+    delete this.length
+  }
+}
+
+module.exports = {
+  ObjectIdField,
+  ObjectIdFieldFromDefinition,
+  FieldFromKeyValue,
+  FieldFromFieldDefinition,
+  StatisticField,
+  StatisticDateField
+}

--- a/lib/helpers/fields/fields.js
+++ b/lib/helpers/fields/fields.js
@@ -1,0 +1,102 @@
+const _ = require('lodash')
+const chalk = require('chalk')
+const {
+  ObjectIdField,
+  FieldFromKeyValue,
+  FieldFromFieldDefinition,
+  ObjectIdFieldFromDefinition
+} = require('./field-classes')
+
+class Fields {
+  static normalizeOptions (inputOptions) {
+    const {
+      features,
+      metadata: {
+        fields,
+        idField
+      } = {},
+      attributeSample,
+      ...options
+    } = inputOptions
+
+    return {
+      idField: options.idField || idField,
+      fieldDefinitions: options.fieldDefinitions || options.fields || fields,
+      attributeSample: attributeSample || getAttributeSample(features, attributeSample),
+      ...options
+    }
+  }
+
+  constructor (options = {}) {
+    const {
+      fieldDefinitions,
+      idField,
+      attributeSample = {}
+    } = options
+
+    if (shouldWarnAboutMissingIdFieldDefinition(idField, fieldDefinitions)) {
+      console.warn(
+        chalk.yellow(`WARNING: provider's "idField" is set to ${idField}, but this field is not found in field-definitions`)
+      )
+    }
+
+    const normalizedIdField = idField || 'OBJECTID'
+
+    this.fields = fieldDefinitions
+      ? setFieldsFromDefinitions(fieldDefinitions, normalizedIdField)
+      : setFieldsFromProperties(attributeSample, normalizedIdField)
+  }
+}
+
+function getAttributeSample (features) {
+  return _.get(features, '[0].properties') || _.get(features, '[0].attributes', {})
+}
+
+function shouldWarnAboutMissingIdFieldDefinition (idField, fieldDefinitions) {
+  if (!idField || !fieldDefinitions) {
+    return
+  }
+
+  const fieldNames = fieldDefinitions.map(field => field.name)
+
+  return !fieldNames.includes(idField)
+}
+
+function setFieldsFromDefinitions (fieldDefinitions, idField) {
+  const fields = fieldDefinitions
+    .filter(fieldDefinition => fieldDefinition.name !== idField)
+    .map(fieldDefinition => {
+      return new FieldFromFieldDefinition(fieldDefinition)
+    })
+
+  const idFieldDefinition = getIdFieldDefinition(fieldDefinitions, idField)
+  fields.unshift(new ObjectIdFieldFromDefinition(idFieldDefinition))
+  return fields
+}
+
+function setFieldsFromProperties (propertiesSample, idField) {
+  const fieldNames = Object.keys(propertiesSample)
+  const simpleFieldNames = fieldNames.filter(name => name !== idField)
+
+  const fields = simpleFieldNames.map((key) => {
+    return new FieldFromKeyValue(key, propertiesSample[key])
+  })
+
+  fields.unshift(new ObjectIdField(idField))
+
+  return fields
+}
+
+function getIdFieldDefinition (fieldDefinitions, idField) {
+  const idFieldDefinition = fieldDefinitions.find(definition => {
+    return definition.name === idField
+  })
+
+  if (idFieldDefinition) {
+    return idFieldDefinition
+  }
+
+  return { name: 'OBJECTID' }
+}
+
+module.exports = Fields

--- a/lib/helpers/fields/index.js
+++ b/lib/helpers/fields/index.js
@@ -1,0 +1,9 @@
+const QueryFields = require('./query-fields')
+const StatisticsFields = require('./statistics-fields')
+const LayerFields = require('./layer-fields')
+
+module.exports = {
+  QueryFields,
+  StatisticsFields,
+  LayerFields
+}

--- a/lib/helpers/fields/layer-fields.js
+++ b/lib/helpers/fields/layer-fields.js
@@ -1,0 +1,19 @@
+const Fields = require('./fields')
+
+class LayerFields extends Fields {
+  static create (inputOptions) {
+    const options = Fields.normalizeOptions(inputOptions)
+    return new LayerFields(options)
+  }
+
+  constructor (options) {
+    super(options)
+
+    return this.fields.map(field => {
+      field.setEditable().setNullable()
+      return field
+    })
+  }
+}
+
+module.exports = LayerFields

--- a/lib/helpers/fields/query-fields.js
+++ b/lib/helpers/fields/query-fields.js
@@ -1,0 +1,31 @@
+const Fields = require('./fields')
+
+class QueryFields extends Fields {
+  static create (inputOptions = {}) {
+    const options = Fields.normalizeOptions(inputOptions)
+    return new QueryFields(options)
+  }
+
+  constructor (options = {}) {
+    super(options)
+
+    const {
+      outFields
+    } = options
+
+    if (outFields && outFields !== '*') {
+      return filterByOutfields(outFields, this.fields)
+    }
+
+    return this.fields
+  }
+}
+
+function filterByOutfields (outFields, fields) {
+  const outFieldNames = outFields.split(/\s*,\s*/)
+  return fields.filter(field => {
+    return outFieldNames.includes(field.name)
+  })
+}
+
+module.exports = QueryFields

--- a/lib/helpers/fields/statistics-fields.js
+++ b/lib/helpers/fields/statistics-fields.js
@@ -1,5 +1,6 @@
-const _ = require('lodash')
 const { isDate } = require('./data-type-utils')
+const { getEsriTypeFromDefinition } = require('./esri-type-utils')
+const { ESRI_FIELD_TYPE_DATE } = require('./constants')
 const {
   StatisticField,
   StatisticDateField,
@@ -75,7 +76,7 @@ function isDateField (regexs, fieldName, value) {
 
 function getDateFieldRegexs (fieldDefinitions = [], outStatistics = []) {
   const dateFields = fieldDefinitions.filter(({ type }) => {
-    return typeIsDate(type)
+    return getEsriTypeFromDefinition(type) === ESRI_FIELD_TYPE_DATE
   }).map(({ name }) => name)
 
   return outStatistics
@@ -90,13 +91,6 @@ function getDateFieldRegexs (fieldDefinitions = [], outStatistics = []) {
       const spaceEscapedName = name.replace(/\s/g, '_')
       return new RegExp(`${spaceEscapedName}$`)
     })
-}
-
-function typeIsDate (type) {
-  if (!_.isString(type)) {
-    return
-  }
-  return type.toLowerCase() === 'date' || type.toLowerCase() === 'esrifieldtypedate'
 }
 
 module.exports = StatisticsFields

--- a/lib/helpers/fields/statistics-fields.js
+++ b/lib/helpers/fields/statistics-fields.js
@@ -1,0 +1,102 @@
+const _ = require('lodash')
+const { isDate } = require('./data-type-utils')
+const {
+  StatisticField,
+  StatisticDateField,
+  FieldFromFieldDefinition,
+  FieldFromKeyValue
+} = require('./field-classes')
+
+class StatisticsFields {
+  static normalizeOptions (inputOptions) {
+    const {
+      statistics,
+      metadata: {
+        fields
+      } = {},
+      groupByFieldsForStatistics = [],
+      attributeSample,
+      ...options
+    } = inputOptions
+
+    return {
+      statisticsSample: Array.isArray(statistics) ? statistics[0] : statistics,
+      fieldDefinitions: options.fieldDefinitions || options.fields || fields,
+      groupByFieldsForStatistics: Array.isArray(groupByFieldsForStatistics) ? groupByFieldsForStatistics : groupByFieldsForStatistics
+        .replace(/\s*,\s*/g, ',')
+        .replace(/^\s/, '')
+        .replace(/\s*$/, '')
+        .split(','),
+      ...options
+    }
+  }
+
+  static create (inputOptions) {
+    const options = StatisticsFields.normalizeOptions(inputOptions)
+    return new StatisticsFields(options)
+  }
+
+  constructor (options = {}) {
+    const {
+      statisticsSample,
+      groupByFieldsForStatistics = [],
+      fieldDefinitions = [],
+      outStatistics
+    } = options
+    const dateFieldRegexs = getDateFieldRegexs(fieldDefinitions, outStatistics)
+
+    return Object
+      .entries(statisticsSample)
+      .map(([key, value]) => {
+        if (groupByFieldsForStatistics.includes(key)) {
+          const fieldDefinition = fieldDefinitions.find(({ name }) => name === key)
+
+          if (fieldDefinition) {
+            return new FieldFromFieldDefinition(fieldDefinition)
+          }
+
+          return new FieldFromKeyValue(key, value)
+        }
+
+        if (isDateField(dateFieldRegexs, key, value)) {
+          return new StatisticDateField(key)
+        }
+
+        return new StatisticField(key)
+      })
+  }
+}
+
+function isDateField (regexs, fieldName, value) {
+  return regexs.some(regex => {
+    return regex.test(fieldName)
+  }) || isDate(value)
+}
+
+function getDateFieldRegexs (fieldDefinitions = [], outStatistics = []) {
+  const dateFields = fieldDefinitions.filter(({ type }) => {
+    return typeIsDate(type)
+  }).map(({ name }) => name)
+
+  return outStatistics
+    .filter(({ onStatisticField }) => dateFields.includes(onStatisticField))
+    .map((statistic) => {
+      const {
+        onStatisticField,
+        outStatisticFieldName
+      } = statistic
+
+      const name = outStatisticFieldName || onStatisticField
+      const spaceEscapedName = name.replace(/\s/g, '_')
+      return new RegExp(`${spaceEscapedName}$`)
+    })
+}
+
+function typeIsDate (type) {
+  if (!_.isString(type)) {
+    return
+  }
+  return type.toLowerCase() === 'date' || type.toLowerCase() === 'esrifieldtypedate'
+}
+
+module.exports = StatisticsFields

--- a/lib/helpers/fields/statistics-fields.js
+++ b/lib/helpers/fields/statistics-fields.js
@@ -9,7 +9,7 @@ const {
 } = require('./field-classes')
 
 class StatisticsFields {
-  static normalizeOptions (inputOptions) {
+  static normalizeOptions (inputOptions = {}) {
     const {
       statistics,
       metadata: {

--- a/lib/helpers/fields/statistics-fields.js
+++ b/lib/helpers/fields/statistics-fields.js
@@ -46,7 +46,7 @@ class StatisticsFields {
     } = options
     const dateFieldRegexs = getDateFieldRegexs(fieldDefinitions, outStatistics)
 
-    return Object
+    this.fields = Object
       .entries(statisticsSample)
       .map(([key, value]) => {
         if (groupByFieldsForStatistics.includes(key)) {
@@ -65,6 +65,8 @@ class StatisticsFields {
 
         return new StatisticField(key)
       })
+
+    return this.fields
   }
 }
 

--- a/test/unit/helpers/fields/constants.spec.js
+++ b/test/unit/helpers/fields/constants.spec.js
@@ -1,0 +1,45 @@
+const should = require('should') // eslint-disable-line
+const {
+  ESRI_FIELD_TYPE_OID,
+  ESRI_FIELD_TYPE_STRING,
+  ESRI_FIELD_TYPE_DATE,
+  ESRI_FIELD_TYPE_DOUBLE,
+  SQL_TYPE_INTEGER,
+  SQL_TYPE_OTHER,
+  SQL_TYPE_FLOAT,
+  OBJECTID_DEFAULT_KEY
+} = require('../../../../lib/helpers/fields/constants')
+
+describe('field constants', () => {
+  it('ESRI_FIELD_TYPE_OID', () => {
+    ESRI_FIELD_TYPE_OID.should.equal('esriFieldTypeOID')
+  })
+
+  it('ESRI_FIELD_TYPE_STRING', () => {
+    ESRI_FIELD_TYPE_STRING.should.equal('esriFieldTypeString')
+  })
+
+  it('ESRI_FIELD_TYPE_DATE', () => {
+    ESRI_FIELD_TYPE_DATE.should.equal('esriFieldTypeDate')
+  })
+
+  it('ESRI_FIELD_TYPE_DOUBLE', () => {
+    ESRI_FIELD_TYPE_DOUBLE.should.equal('esriFieldTypeDouble')
+  })
+
+  it('SQL_TYPE_INTEGER', () => {
+    SQL_TYPE_INTEGER.should.equal('sqlTypeInteger')
+  })
+
+  it('SQL_TYPE_OTHER', () => {
+    SQL_TYPE_OTHER.should.equal('sqlTypeOther')
+  })
+
+  it('SQL_TYPE_FLOAT', () => {
+    SQL_TYPE_FLOAT.should.equal('sqlTypeFloat')
+  })
+
+  it('OBJECTID_DEFAULT_KEY', () => {
+    OBJECTID_DEFAULT_KEY.should.equal('OBJECTID')
+  })
+})

--- a/test/unit/helpers/fields/data-type-utils.spec.js
+++ b/test/unit/helpers/fields/data-type-utils.spec.js
@@ -1,0 +1,45 @@
+const should = require('should') // eslint-disable-line
+const {
+  getDataTypeFromValue,
+  isDate
+} = require('../../../../lib/helpers/fields/data-type-utils')
+
+describe('getDataTypeFromValue', () => {
+  it('should return integer', () => {
+    getDataTypeFromValue(10).should.equal('Integer')
+  })
+
+  it('should return double', () => {
+    getDataTypeFromValue(10.10).should.equal('Double')
+  })
+
+  it('should return string', () => {
+    getDataTypeFromValue('10.10').should.equal('String')
+  })
+
+  it('should return string as default', () => {
+    getDataTypeFromValue().should.equal('String')
+  })
+
+  it('should return date for date object', () => {
+    getDataTypeFromValue(new Date()).should.equal('Date')
+  })
+
+  it('should return date for data ISO string', () => {
+    getDataTypeFromValue(new Date().toISOString()).should.equal('Date')
+  })
+})
+
+describe('isDate', () => {
+  it('should return true for date object', () => {
+    isDate(new Date()).should.equal(true)
+  })
+
+  it('should return true for ISO string', () => {
+    getDataTypeFromValue(new Date().toISOString()).should.equal('Date')
+  })
+
+  it('should return false for number', () => {
+    isDate(1000).should.equal(false)
+  })
+})

--- a/test/unit/helpers/fields/esri-type-utils.spec.js
+++ b/test/unit/helpers/fields/esri-type-utils.spec.js
@@ -1,0 +1,96 @@
+const should = require('should') // eslint-disable-line
+const {
+  getEsriTypeFromDefinition,
+  getEsriTypeFromValue
+} = require('../../../../lib/helpers/fields/esri-type-utils')
+
+describe('getEsriTypeFromDefinition', () => {
+  it('no definition should default to string', () => {
+    const result = getEsriTypeFromDefinition()
+    result.should.equal('esriFieldTypeString')
+  })
+
+  it('string', () => {
+    getEsriTypeFromDefinition('String').should.equal('esriFieldTypeString')
+    getEsriTypeFromDefinition('string').should.equal('esriFieldTypeString')
+  })
+
+  it('double', () => {
+    getEsriTypeFromDefinition('Double').should.equal('esriFieldTypeDouble')
+    getEsriTypeFromDefinition('double').should.equal('esriFieldTypeDouble')
+  })
+
+  it('integer', () => {
+    getEsriTypeFromDefinition('Integer').should.equal('esriFieldTypeInteger')
+    getEsriTypeFromDefinition('integer').should.equal('esriFieldTypeInteger')
+  })
+
+  it('date', () => {
+    getEsriTypeFromDefinition('Date').should.equal('esriFieldTypeDate')
+    getEsriTypeFromDefinition('date').should.equal('esriFieldTypeDate')
+  })
+
+  it('blob', () => {
+    getEsriTypeFromDefinition('Blob').should.equal('esriFieldTypeBlob')
+    getEsriTypeFromDefinition('blob').should.equal('esriFieldTypeBlob')
+  })
+
+  it('geometry', () => {
+    getEsriTypeFromDefinition('Geometry').should.equal('esriFieldTypeGeometry')
+    getEsriTypeFromDefinition('geometry').should.equal('esriFieldTypeGeometry')
+  })
+
+  it('globalid', () => {
+    getEsriTypeFromDefinition('GlobalID').should.equal('esriFieldTypeGlobalID')
+    getEsriTypeFromDefinition('globalid').should.equal('esriFieldTypeGlobalID')
+  })
+
+  it('guid', () => {
+    getEsriTypeFromDefinition('GUID').should.equal('esriFieldTypeGUID')
+    getEsriTypeFromDefinition('guid').should.equal('esriFieldTypeGUID')
+  })
+
+  it('raster', () => {
+    getEsriTypeFromDefinition('Raster').should.equal('esriFieldTypeRaster')
+    getEsriTypeFromDefinition('raster').should.equal('esriFieldTypeRaster')
+  })
+
+  it('single', () => {
+    getEsriTypeFromDefinition('Single').should.equal('esriFieldTypeSingle')
+    getEsriTypeFromDefinition('single').should.equal('esriFieldTypeSingle')
+  })
+
+  it('small-integer', () => {
+    getEsriTypeFromDefinition('SmallInteger').should.equal('esriFieldTypeSmallInteger')
+    getEsriTypeFromDefinition('smallinteger').should.equal('esriFieldTypeSmallInteger')
+  })
+
+  it('xml', () => {
+    getEsriTypeFromDefinition('XML').should.equal('esriFieldTypeXML')
+    getEsriTypeFromDefinition('xml').should.equal('esriFieldTypeXML')
+  })
+})
+
+describe('getEsriTypeFromValue', () => {
+  it('no value should default to string', () => {
+    const result = getEsriTypeFromValue()
+    result.should.equal('esriFieldTypeString')
+  })
+
+  it('string', () => {
+    getEsriTypeFromValue('some-string').should.equal('esriFieldTypeString')
+  })
+
+  it('double', () => {
+    getEsriTypeFromValue(3.145678).should.equal('esriFieldTypeDouble')
+  })
+
+  it('integer', () => {
+    getEsriTypeFromValue(2).should.equal('esriFieldTypeInteger')
+  })
+
+  it('date', () => {
+    getEsriTypeFromValue(new Date()).should.equal('esriFieldTypeDate')
+    getEsriTypeFromValue((new Date()).toISOString()).should.equal('esriFieldTypeDate')
+  })
+})

--- a/test/unit/helpers/fields/field-classes.spec.js
+++ b/test/unit/helpers/fields/field-classes.spec.js
@@ -195,7 +195,7 @@ describe('ObjectIdFieldFromFieldDefinition', () => {
   })
 })
 
-describe('StatiticsField', () => {
+describe('StatisticsField', () => {
   it('should produce expected instance', () => {
     const result = new StatisticField('foo')
     result.should.deepEqual({
@@ -209,7 +209,7 @@ describe('StatiticsField', () => {
   })
 })
 
-describe('StatiticsDateField', () => {
+describe('StatisticsDateField', () => {
   it('should produce expected instance', () => {
     const result = new StatisticDateField('foo')
     result.should.deepEqual({

--- a/test/unit/helpers/fields/field-classes.spec.js
+++ b/test/unit/helpers/fields/field-classes.spec.js
@@ -1,0 +1,224 @@
+const should = require('should') // eslint-disable-line
+should.config.checkProtoEql = false
+const {
+  FieldFromKeyValue,
+  ObjectIdField,
+  FieldFromFieldDefinition,
+  ObjectIdFieldFromDefinition,
+  StatisticField,
+  StatisticDateField
+} = require('../../../../lib/helpers/fields/field-classes')
+
+describe('FieldFromKeyValue', () => {
+  it('should produce expected instance', () => {
+    const result = new FieldFromKeyValue('foo', 'bar')
+    result.should.deepEqual({
+      name: 'foo',
+      alias: 'foo',
+      type: 'esriFieldTypeString',
+      sqlType: 'sqlTypeOther',
+      length: 128,
+      domain: null,
+      defaultValue: null
+    })
+
+    result.setEditable().setNullable()
+    result.should.deepEqual({
+      name: 'foo',
+      alias: 'foo',
+      type: 'esriFieldTypeString',
+      sqlType: 'sqlTypeOther',
+      length: 128,
+      domain: null,
+      defaultValue: null,
+      editable: false,
+      nullable: false
+    })
+
+    result.setEditable(true).setNullable(true)
+    result.should.deepEqual({
+      name: 'foo',
+      alias: 'foo',
+      type: 'esriFieldTypeString',
+      sqlType: 'sqlTypeOther',
+      length: 128,
+      domain: null,
+      defaultValue: null,
+      editable: true,
+      nullable: true
+    })
+  })
+})
+
+describe('ObjectIdField', () => {
+  it('should produce expected instance', () => {
+    const result = new ObjectIdField('idFoo')
+    result.should.deepEqual({
+      name: 'idFoo',
+      alias: 'idFoo',
+      type: 'esriFieldTypeOID',
+      sqlType: 'sqlTypeInteger',
+      domain: null,
+      defaultValue: null
+    })
+
+    result.setEditable().setNullable()
+    result.should.deepEqual({
+      name: 'idFoo',
+      alias: 'idFoo',
+      type: 'esriFieldTypeOID',
+      sqlType: 'sqlTypeInteger',
+      domain: null,
+      defaultValue: null,
+      editable: false,
+      nullable: false
+    })
+
+    result.setEditable(true).setNullable(true)
+    result.should.deepEqual({
+      name: 'idFoo',
+      alias: 'idFoo',
+      type: 'esriFieldTypeOID',
+      sqlType: 'sqlTypeInteger',
+      domain: null,
+      defaultValue: null,
+      editable: true,
+      nullable: true
+    })
+  })
+})
+
+describe('FieldFromFieldDefinition', () => {
+  it('should produce expected instance from name, type definitions', () => {
+    const result = new FieldFromFieldDefinition({
+      name: 'foo',
+      type: 'String'
+    })
+    result.should.deepEqual({
+      name: 'foo',
+      alias: 'foo',
+      type: 'esriFieldTypeString',
+      sqlType: 'sqlTypeOther',
+      length: 128,
+      domain: null,
+      defaultValue: null
+    })
+
+    result.setEditable().setNullable()
+    result.should.deepEqual({
+      name: 'foo',
+      alias: 'foo',
+      type: 'esriFieldTypeString',
+      sqlType: 'sqlTypeOther',
+      length: 128,
+      domain: null,
+      defaultValue: null,
+      editable: false,
+      nullable: false
+    })
+
+    result.setEditable(true).setNullable(true)
+    result.should.deepEqual({
+      name: 'foo',
+      alias: 'foo',
+      type: 'esriFieldTypeString',
+      sqlType: 'sqlTypeOther',
+      length: 128,
+      domain: null,
+      defaultValue: null,
+      editable: true,
+      nullable: true
+    })
+  })
+
+  it('should produce expected instance from name, type, plus all optional definitions', () => {
+    const result = new FieldFromFieldDefinition({
+      name: 'foo',
+      type: 'String',
+      alias: 'foolish',
+      domain: 'domain-value',
+      defaultValue: 'default-value',
+      length: 256
+    })
+    result.should.deepEqual({
+      name: 'foo',
+      alias: 'foolish',
+      type: 'esriFieldTypeString',
+      sqlType: 'sqlTypeOther',
+      domain: 'domain-value',
+      defaultValue: 'default-value',
+      length: 256
+    })
+  })
+})
+
+describe('ObjectIdFieldFromFieldDefinition', () => {
+  it('should produce expected instance', () => {
+    const result = new ObjectIdFieldFromDefinition({
+      name: 'foo',
+      type: 'String',
+      editable: true,
+      nullable: true
+    })
+    result.should.deepEqual({
+      name: 'foo',
+      alias: 'foo',
+      type: 'esriFieldTypeOID',
+      sqlType: 'sqlTypeInteger',
+      domain: null,
+      defaultValue: null
+    })
+
+    result.setEditable().setNullable()
+    result.should.deepEqual({
+      name: 'foo',
+      alias: 'foo',
+      type: 'esriFieldTypeOID',
+      sqlType: 'sqlTypeInteger',
+      domain: null,
+      defaultValue: null,
+      editable: false,
+      nullable: false
+    })
+
+    result.setEditable(true).setNullable(true)
+    result.should.deepEqual({
+      name: 'foo',
+      alias: 'foo',
+      type: 'esriFieldTypeOID',
+      sqlType: 'sqlTypeInteger',
+      domain: null,
+      defaultValue: null,
+      editable: true,
+      nullable: true
+    })
+  })
+})
+
+describe('StatiticsField', () => {
+  it('should produce expected instance', () => {
+    const result = new StatisticField('foo')
+    result.should.deepEqual({
+      name: 'foo',
+      alias: 'foo',
+      type: 'esriFieldTypeDouble',
+      sqlType: 'sqlTypeFloat',
+      domain: null,
+      defaultValue: null
+    })
+  })
+})
+
+describe('StatiticsDateField', () => {
+  it('should produce expected instance', () => {
+    const result = new StatisticDateField('foo')
+    result.should.deepEqual({
+      name: 'foo',
+      alias: 'foo',
+      type: 'esriFieldTypeDate',
+      sqlType: 'sqlTypeOther',
+      domain: null,
+      defaultValue: null
+    })
+  })
+})

--- a/test/unit/helpers/fields/fields.spec.js
+++ b/test/unit/helpers/fields/fields.spec.js
@@ -1,0 +1,261 @@
+const should = require('should') // eslint-disable-line
+should.config.checkProtoEql = false
+const Fields = require('../../../../lib/helpers/fields/fields')
+
+describe('Fields', () => {
+  describe('static normalizeOptions method', () => {
+    it('should defer to fieldsDefinitions when supplied', () => {
+      const { fieldDefinitions } = Fields.normalizeOptions({
+        fieldDefinitions: 'foo',
+        fields: 'bar',
+        metadata: {
+          fields: 'snafu'
+        }
+      })
+
+      fieldDefinitions.should.equal('foo')
+    })
+
+    it('should defer to root-level "fields" when supplied', () => {
+      const { fieldDefinitions } = Fields.normalizeOptions({
+        fields: 'bar',
+        metadata: {
+          fields: 'snafu'
+        }
+      })
+
+      fieldDefinitions.should.equal('bar')
+    })
+
+    it('should use "metadata.fields" when supplied', () => {
+      const { fieldDefinitions } = Fields.normalizeOptions({
+        metadata: {
+          fields: 'snafu'
+        }
+      })
+
+      fieldDefinitions.should.equal('snafu')
+    })
+
+    it('should defer to root-level "idField" when supplied', () => {
+      const { idField } = Fields.normalizeOptions({
+        idField: 'bar',
+        metadata: {
+          idField: 'snafu'
+        }
+      })
+
+      idField.should.equal('bar')
+    })
+
+    it('should use "metadata.idField" when supplied', () => {
+      const { idField } = Fields.normalizeOptions({
+        metadata: {
+          idField: 'snafu'
+        }
+      })
+
+      idField.should.equal('snafu')
+    })
+
+    it('should defer to root-level "attributeSample" when supplied', () => {
+      const { attributeSample } = Fields.normalizeOptions({
+        attributeSample: 'bar'
+      })
+
+      attributeSample.should.equal('bar')
+    })
+
+    it('should acquire "attributeSample" from features[0].attributes', () => {
+      const { attributeSample } = Fields.normalizeOptions({
+        features: [
+          { attributes: { name: 'foo' } },
+          { attributes: { name: 'bar' } }
+        ]
+      })
+
+      attributeSample.should.deepEqual({ name: 'foo' })
+    })
+
+    it('should acquire "attributeSample" from features[0].properties', () => {
+      const { attributeSample } = Fields.normalizeOptions({
+        features: [
+          { properties: { name: 'foo' } },
+          { properties: { name: 'bar' } }
+        ]
+      })
+
+      attributeSample.should.deepEqual({ name: 'foo' })
+    })
+
+    it('should have "attributeSample" default to empty object', () => {
+      const { attributeSample } = Fields.normalizeOptions({
+        features: []
+      })
+
+      attributeSample.should.deepEqual({})
+    })
+  })
+
+  describe('constructor', () => {
+    it('should set fields from definitions, add OBJECTID', () => {
+      const fields = new Fields({
+        fieldDefinitions: [
+          { name: 'foo', type: 'String' }
+        ]
+      })
+
+      fields.should.deepEqual({
+        fields: [{
+          name: 'OBJECTID',
+          type: 'esriFieldTypeOID',
+          alias: 'OBJECTID',
+          sqlType: 'sqlTypeInteger',
+          domain: null,
+          defaultValue: null
+        }, {
+          name: 'foo',
+          type: 'esriFieldTypeString',
+          alias: 'foo',
+          sqlType: 'sqlTypeOther',
+          domain: null,
+          defaultValue: null,
+          length: 128
+        }]
+      })
+    })
+
+    it('should set fields from definitions, including OBJECTID', () => {
+      const fields = new Fields({
+        fieldDefinitions: [
+          { name: 'foo', type: 'String' },
+          { name: 'OBJECTID', type: 'Integer' }
+        ]
+      })
+
+      fields.should.deepEqual({
+        fields: [{
+          name: 'OBJECTID',
+          type: 'esriFieldTypeOID',
+          alias: 'OBJECTID',
+          sqlType: 'sqlTypeInteger',
+          domain: null,
+          defaultValue: null
+        }, {
+          name: 'foo',
+          type: 'esriFieldTypeString',
+          alias: 'foo',
+          sqlType: 'sqlTypeOther',
+          domain: null,
+          defaultValue: null,
+          length: 128
+        }]
+      })
+    })
+
+    it('should set fields from definitions, noting idField as OBJECTID', () => {
+      const fields = new Fields({
+        idField: 'bar',
+        fieldDefinitions: [
+          { name: 'foo', type: 'String' },
+          { name: 'bar', type: 'Integer' }
+        ]
+      })
+
+      fields.should.deepEqual({
+        fields: [{
+          name: 'bar',
+          type: 'esriFieldTypeOID',
+          alias: 'bar',
+          sqlType: 'sqlTypeInteger',
+          domain: null,
+          defaultValue: null
+        }, {
+          name: 'foo',
+          type: 'esriFieldTypeString',
+          alias: 'foo',
+          sqlType: 'sqlTypeOther',
+          domain: null,
+          defaultValue: null,
+          length: 128
+        }]
+      })
+    })
+
+    it('should set fields from attributeSample, add OBJECTID', () => {
+      const fields = new Fields({
+        attributeSample: { foo: 'bar' }
+      })
+
+      fields.should.deepEqual({
+        fields: [{
+          name: 'OBJECTID',
+          type: 'esriFieldTypeOID',
+          alias: 'OBJECTID',
+          sqlType: 'sqlTypeInteger',
+          domain: null,
+          defaultValue: null
+        }, {
+          name: 'foo',
+          type: 'esriFieldTypeString',
+          alias: 'foo',
+          sqlType: 'sqlTypeOther',
+          domain: null,
+          defaultValue: null,
+          length: 128
+        }]
+      })
+    })
+
+    it('should set fields from attributeSample, use included OBJECTID', () => {
+      const fields = new Fields({
+        attributeSample: { OBJECTID: 1234, foo: 'bar' }
+      })
+
+      fields.should.deepEqual({
+        fields: [{
+          name: 'OBJECTID',
+          type: 'esriFieldTypeOID',
+          alias: 'OBJECTID',
+          sqlType: 'sqlTypeInteger',
+          domain: null,
+          defaultValue: null
+        }, {
+          name: 'foo',
+          type: 'esriFieldTypeString',
+          alias: 'foo',
+          sqlType: 'sqlTypeOther',
+          domain: null,
+          defaultValue: null,
+          length: 128
+        }]
+      })
+    })
+
+    it('should set fields from attributeSample, use included OBJECTID', () => {
+      const fields = new Fields({
+        idField: 'hello',
+        attributeSample: { hello: 1234, foo: 'bar' }
+      })
+
+      fields.should.deepEqual({
+        fields: [{
+          name: 'hello',
+          type: 'esriFieldTypeOID',
+          alias: 'hello',
+          sqlType: 'sqlTypeInteger',
+          domain: null,
+          defaultValue: null
+        }, {
+          name: 'foo',
+          type: 'esriFieldTypeString',
+          alias: 'foo',
+          sqlType: 'sqlTypeOther',
+          domain: null,
+          defaultValue: null,
+          length: 128
+        }]
+      })
+    })
+  })
+})

--- a/test/unit/helpers/fields/layer-fields.spec.js
+++ b/test/unit/helpers/fields/layer-fields.spec.js
@@ -1,0 +1,263 @@
+const should = require('should') // eslint-disable-line
+should.config.checkProtoEql = false
+const LayerFields = require('../../../../lib/helpers/fields/layer-fields')
+
+describe('LayerFields', () => {
+  it('create fields from definitions, adds OBJECTID', () => {
+    const result = LayerFields.create({
+      fields: [
+        { name: 'foo', type: 'String' }
+      ]
+    })
+    result.should.deepEqual([{
+      name: 'OBJECTID',
+      alias: 'OBJECTID',
+      type: 'esriFieldTypeOID',
+      sqlType: 'sqlTypeInteger',
+      domain: null,
+      defaultValue: null,
+      editable: false,
+      nullable: false
+    }, {
+      name: 'foo',
+      alias: 'foo',
+      type: 'esriFieldTypeString',
+      sqlType: 'sqlTypeOther',
+      length: 128,
+      domain: null,
+      defaultValue: null,
+      editable: false,
+      nullable: false
+    }])
+  })
+
+  it('create fields from definitions, assign idField as OBJECTID', () => {
+    const result = LayerFields.create({
+      fields: [
+        { name: 'foo', type: 'Integer' }
+      ],
+      idField: 'foo'
+    })
+    result.should.deepEqual([{
+      name: 'foo',
+      alias: 'foo',
+      type: 'esriFieldTypeOID',
+      sqlType: 'sqlTypeInteger',
+      domain: null,
+      defaultValue: null,
+      editable: false,
+      nullable: false
+    }])
+  })
+
+  it('create fields from attributes sample, adds OBJECTID', () => {
+    const result = LayerFields.create({
+      attributeSample: {
+        foo: 'bar'
+      }
+    })
+    result.should.deepEqual([{
+      name: 'OBJECTID',
+      alias: 'OBJECTID',
+      type: 'esriFieldTypeOID',
+      sqlType: 'sqlTypeInteger',
+      domain: null,
+      defaultValue: null,
+      editable: false,
+      nullable: false
+    }, {
+      name: 'foo',
+      alias: 'foo',
+      type: 'esriFieldTypeString',
+      sqlType: 'sqlTypeOther',
+      length: 128,
+      domain: null,
+      defaultValue: null,
+      editable: false,
+      nullable: false
+    }])
+  })
+
+  it('create fields from attributes sample, finds and uses OBJECTID', () => {
+    const result = LayerFields.create({
+      attributeSample: {
+        foo: 'bar',
+        OBJECTID: 1
+      }
+    })
+    result.should.deepEqual([{
+      name: 'OBJECTID',
+      alias: 'OBJECTID',
+      type: 'esriFieldTypeOID',
+      sqlType: 'sqlTypeInteger',
+      domain: null,
+      defaultValue: null,
+      editable: false,
+      nullable: false
+    }, {
+      name: 'foo',
+      alias: 'foo',
+      type: 'esriFieldTypeString',
+      sqlType: 'sqlTypeOther',
+      length: 128,
+      domain: null,
+      defaultValue: null,
+      editable: false,
+      nullable: false
+    }])
+  })
+
+  it('create fields from attributes sample, adds OBJECTID', () => {
+    const result = LayerFields.create({
+      attributeSample: {
+        foo: 'bar'
+      }
+    })
+    result.should.deepEqual([{
+      name: 'OBJECTID',
+      alias: 'OBJECTID',
+      type: 'esriFieldTypeOID',
+      sqlType: 'sqlTypeInteger',
+      domain: null,
+      defaultValue: null,
+      editable: false,
+      nullable: false
+    }, {
+      name: 'foo',
+      alias: 'foo',
+      type: 'esriFieldTypeString',
+      sqlType: 'sqlTypeOther',
+      length: 128,
+      domain: null,
+      defaultValue: null,
+      editable: false,
+      nullable: false
+    }])
+  })
+
+  it('create fields from geojson data, adds OBJECTID', () => {
+    const result = LayerFields.create({
+      features: [{
+        properties: {
+          foo: 'bar'
+        }
+      }]
+    })
+
+    result.should.deepEqual([{
+      name: 'OBJECTID',
+      alias: 'OBJECTID',
+      type: 'esriFieldTypeOID',
+      sqlType: 'sqlTypeInteger',
+      domain: null,
+      defaultValue: null,
+      editable: false,
+      nullable: false
+    }, {
+      name: 'foo',
+      alias: 'foo',
+      type: 'esriFieldTypeString',
+      sqlType: 'sqlTypeOther',
+      length: 128,
+      domain: null,
+      defaultValue: null,
+      editable: false,
+      nullable: false
+    }])
+  })
+
+  it('create fields from geojson data, finds and uses OBJECTID', () => {
+    const result = LayerFields.create({
+      features: [{
+        properties: {
+          OBJECTID: 1,
+          foo: 'bar'
+        }
+      }]
+    })
+
+    result.should.deepEqual([{
+      name: 'OBJECTID',
+      alias: 'OBJECTID',
+      type: 'esriFieldTypeOID',
+      sqlType: 'sqlTypeInteger',
+      domain: null,
+      defaultValue: null,
+      editable: false,
+      nullable: false
+    }, {
+      name: 'foo',
+      alias: 'foo',
+      type: 'esriFieldTypeString',
+      sqlType: 'sqlTypeOther',
+      length: 128,
+      domain: null,
+      defaultValue: null,
+      editable: false,
+      nullable: false
+    }])
+  })
+
+  it('create fields from esri json data, adds OBJECTID', () => {
+    const result = LayerFields.create({
+      features: [{
+        attributes: {
+          foo: 'bar'
+        }
+      }]
+    })
+
+    result.should.deepEqual([{
+      name: 'OBJECTID',
+      alias: 'OBJECTID',
+      type: 'esriFieldTypeOID',
+      sqlType: 'sqlTypeInteger',
+      domain: null,
+      defaultValue: null,
+      editable: false,
+      nullable: false
+    }, {
+      name: 'foo',
+      alias: 'foo',
+      type: 'esriFieldTypeString',
+      sqlType: 'sqlTypeOther',
+      length: 128,
+      domain: null,
+      defaultValue: null,
+      editable: false,
+      nullable: false
+    }])
+  })
+
+  it('create fields from esri json data, finds and uses OBJECTID', () => {
+    const result = LayerFields.create({
+      features: [{
+        attributes: {
+          OBJECTID: 1,
+          foo: 'bar'
+        }
+      }]
+    })
+
+    result.should.deepEqual([{
+      name: 'OBJECTID',
+      alias: 'OBJECTID',
+      type: 'esriFieldTypeOID',
+      sqlType: 'sqlTypeInteger',
+      domain: null,
+      defaultValue: null,
+      editable: false,
+      nullable: false
+    }, {
+      name: 'foo',
+      alias: 'foo',
+      type: 'esriFieldTypeString',
+      sqlType: 'sqlTypeOther',
+      length: 128,
+      domain: null,
+      defaultValue: null,
+      editable: false,
+      nullable: false
+    }])
+  })
+})

--- a/test/unit/helpers/fields/query-fields.spec.js
+++ b/test/unit/helpers/fields/query-fields.spec.js
@@ -1,0 +1,359 @@
+const should = require('should') // eslint-disable-line
+should.config.checkProtoEql = false
+const QueryFields = require('../../../../lib/helpers/fields/query-fields')
+
+describe('QueryFields', () => {
+  it('create fields from definitions, adds OBJECTID', () => {
+    const result = QueryFields.create({
+      fields: [
+        { name: 'foo', type: 'String' }
+      ]
+    })
+    result.should.deepEqual([{
+      name: 'OBJECTID',
+      alias: 'OBJECTID',
+      type: 'esriFieldTypeOID',
+      sqlType: 'sqlTypeInteger',
+      domain: null,
+      defaultValue: null
+    }, {
+      name: 'foo',
+      alias: 'foo',
+      type: 'esriFieldTypeString',
+      sqlType: 'sqlTypeOther',
+      length: 128,
+      domain: null,
+      defaultValue: null
+    }])
+  })
+
+  it('create fields from definitions, assign idField as OBJECTID', () => {
+    const result = QueryFields.create({
+      fields: [
+        { name: 'foo', type: 'Integer' }
+      ],
+      idField: 'foo'
+    })
+    result.should.deepEqual([{
+      name: 'foo',
+      alias: 'foo',
+      type: 'esriFieldTypeOID',
+      sqlType: 'sqlTypeInteger',
+      domain: null,
+      defaultValue: null
+    }])
+  })
+
+  it('create fields from attributes sample, adds OBJECTID', () => {
+    const result = QueryFields.create({
+      attributeSample: {
+        foo: 'bar'
+      }
+    })
+    result.should.deepEqual([{
+      name: 'OBJECTID',
+      alias: 'OBJECTID',
+      type: 'esriFieldTypeOID',
+      sqlType: 'sqlTypeInteger',
+      domain: null,
+      defaultValue: null
+    }, {
+      name: 'foo',
+      alias: 'foo',
+      type: 'esriFieldTypeString',
+      sqlType: 'sqlTypeOther',
+      length: 128,
+      domain: null,
+      defaultValue: null
+    }])
+  })
+
+  it('create fields from attributes sample, finds and uses OBJECTID', () => {
+    const result = QueryFields.create({
+      attributeSample: {
+        foo: 'bar',
+        OBJECTID: 1
+      }
+    })
+    result.should.deepEqual([{
+      name: 'OBJECTID',
+      alias: 'OBJECTID',
+      type: 'esriFieldTypeOID',
+      sqlType: 'sqlTypeInteger',
+      domain: null,
+      defaultValue: null
+    }, {
+      name: 'foo',
+      alias: 'foo',
+      type: 'esriFieldTypeString',
+      sqlType: 'sqlTypeOther',
+      length: 128,
+      domain: null,
+      defaultValue: null
+    }])
+  })
+
+  it('create fields from attributes sample, adds OBJECTID', () => {
+    const result = QueryFields.create({
+      attributeSample: {
+        foo: 'bar'
+      }
+    })
+    result.should.deepEqual([{
+      name: 'OBJECTID',
+      alias: 'OBJECTID',
+      type: 'esriFieldTypeOID',
+      sqlType: 'sqlTypeInteger',
+      domain: null,
+      defaultValue: null
+    }, {
+      name: 'foo',
+      alias: 'foo',
+      type: 'esriFieldTypeString',
+      sqlType: 'sqlTypeOther',
+      length: 128,
+      domain: null,
+      defaultValue: null
+    }])
+  })
+
+  it('create fields from geojson data, adds OBJECTID', () => {
+    const result = QueryFields.create({
+      features: [{
+        properties: {
+          foo: 'bar'
+        }
+      }]
+    })
+
+    result.should.deepEqual([{
+      name: 'OBJECTID',
+      alias: 'OBJECTID',
+      type: 'esriFieldTypeOID',
+      sqlType: 'sqlTypeInteger',
+      domain: null,
+      defaultValue: null
+    }, {
+      name: 'foo',
+      alias: 'foo',
+      type: 'esriFieldTypeString',
+      sqlType: 'sqlTypeOther',
+      length: 128,
+      domain: null,
+      defaultValue: null
+    }])
+  })
+
+  it('create fields from geojson data, finds and uses OBJECTID', () => {
+    const result = QueryFields.create({
+      features: [{
+        properties: {
+          OBJECTID: 1,
+          foo: 'bar'
+        }
+      }]
+    })
+
+    result.should.deepEqual([{
+      name: 'OBJECTID',
+      alias: 'OBJECTID',
+      type: 'esriFieldTypeOID',
+      sqlType: 'sqlTypeInteger',
+      domain: null,
+      defaultValue: null
+    }, {
+      name: 'foo',
+      alias: 'foo',
+      type: 'esriFieldTypeString',
+      sqlType: 'sqlTypeOther',
+      length: 128,
+      domain: null,
+      defaultValue: null
+    }])
+  })
+
+  it('create fields from esri json data, adds OBJECTID', () => {
+    const result = QueryFields.create({
+      features: [{
+        attributes: {
+          foo: 'bar'
+        }
+      }]
+    })
+
+    result.should.deepEqual([{
+      name: 'OBJECTID',
+      alias: 'OBJECTID',
+      type: 'esriFieldTypeOID',
+      sqlType: 'sqlTypeInteger',
+      domain: null,
+      defaultValue: null
+    }, {
+      name: 'foo',
+      alias: 'foo',
+      type: 'esriFieldTypeString',
+      sqlType: 'sqlTypeOther',
+      length: 128,
+      domain: null,
+      defaultValue: null
+    }])
+  })
+
+  it('create fields from esri json data, finds and uses OBJECTID', () => {
+    const result = QueryFields.create({
+      features: [{
+        attributes: {
+          OBJECTID: 1,
+          foo: 'bar'
+        }
+      }]
+    })
+
+    result.should.deepEqual([{
+      name: 'OBJECTID',
+      alias: 'OBJECTID',
+      type: 'esriFieldTypeOID',
+      sqlType: 'sqlTypeInteger',
+      domain: null,
+      defaultValue: null
+    }, {
+      name: 'foo',
+      alias: 'foo',
+      type: 'esriFieldTypeString',
+      sqlType: 'sqlTypeOther',
+      length: 128,
+      domain: null,
+      defaultValue: null
+    }])
+  })
+
+  it('outFields option filters fields array', () => {
+    const result = QueryFields.create({
+      fields: [
+        { name: 'foo', type: 'String' },
+        { name: 'bar', type: 'String' },
+        { name: 'hello', type: 'String' }
+      ],
+      outFields: 'foo,hello'
+    })
+    result.should.deepEqual([{
+      name: 'foo',
+      alias: 'foo',
+      type: 'esriFieldTypeString',
+      sqlType: 'sqlTypeOther',
+      length: 128,
+      domain: null,
+      defaultValue: null
+    }, {
+      name: 'hello',
+      alias: 'hello',
+      type: 'esriFieldTypeString',
+      sqlType: 'sqlTypeOther',
+      length: 128,
+      domain: null,
+      defaultValue: null
+    }])
+  })
+
+  it('outFields wildcard does not filter fields array', () => {
+    const result = QueryFields.create({
+      fields: [
+        { name: 'foo', type: 'String' },
+        { name: 'hello', type: 'String' }
+      ],
+      outFields: '*'
+    })
+    result.should.deepEqual([{
+      name: 'OBJECTID',
+      alias: 'OBJECTID',
+      type: 'esriFieldTypeOID',
+      sqlType: 'sqlTypeInteger',
+      domain: null,
+      defaultValue: null
+    }, {
+      name: 'foo',
+      alias: 'foo',
+      type: 'esriFieldTypeString',
+      sqlType: 'sqlTypeOther',
+      length: 128,
+      domain: null,
+      defaultValue: null
+    }, {
+      name: 'hello',
+      alias: 'hello',
+      type: 'esriFieldTypeString',
+      sqlType: 'sqlTypeOther',
+      length: 128,
+      domain: null,
+      defaultValue: null
+    }])
+  })
+
+  it('outFields empty string does not filter fields array', () => {
+    const result = QueryFields.create({
+      fields: [
+        { name: 'foo', type: 'String' },
+        { name: 'hello', type: 'String' }
+      ],
+      outFields: ''
+    })
+    result.should.deepEqual([{
+      name: 'OBJECTID',
+      alias: 'OBJECTID',
+      type: 'esriFieldTypeOID',
+      sqlType: 'sqlTypeInteger',
+      domain: null,
+      defaultValue: null
+    }, {
+      name: 'foo',
+      alias: 'foo',
+      type: 'esriFieldTypeString',
+      sqlType: 'sqlTypeOther',
+      length: 128,
+      domain: null,
+      defaultValue: null
+    }, {
+      name: 'hello',
+      alias: 'hello',
+      type: 'esriFieldTypeString',
+      sqlType: 'sqlTypeOther',
+      length: 128,
+      domain: null,
+      defaultValue: null
+    }])
+  })
+
+  it('outFields null value does not filter fields array', () => {
+    const result = QueryFields.create({
+      fields: [
+        { name: 'foo', type: 'String' },
+        { name: 'hello', type: 'String' }
+      ],
+      outFields: null
+    })
+    result.should.deepEqual([{
+      name: 'OBJECTID',
+      alias: 'OBJECTID',
+      type: 'esriFieldTypeOID',
+      sqlType: 'sqlTypeInteger',
+      domain: null,
+      defaultValue: null
+    }, {
+      name: 'foo',
+      alias: 'foo',
+      type: 'esriFieldTypeString',
+      sqlType: 'sqlTypeOther',
+      length: 128,
+      domain: null,
+      defaultValue: null
+    }, {
+      name: 'hello',
+      alias: 'hello',
+      type: 'esriFieldTypeString',
+      sqlType: 'sqlTypeOther',
+      length: 128,
+      domain: null,
+      defaultValue: null
+    }])
+  })
+})

--- a/test/unit/helpers/fields/statistics-fields.spec.js
+++ b/test/unit/helpers/fields/statistics-fields.spec.js
@@ -1,0 +1,171 @@
+const should = require('should') // eslint-disable-line
+should.config.checkProtoEql = false
+const StatisticsFields = require('../../../../lib/helpers/fields/statistics-fields')
+
+describe('StatisticsFields', () => {
+  describe('static normalizeOptions method', () => {
+    it('should use first element of statistics array as sample', () => {
+      const { statisticsSample } = StatisticsFields.normalizeOptions({
+        statistics: [{ foo: '1.234' }]
+      })
+
+      statisticsSample.should.deepEqual({ foo: '1.234' })
+    })
+
+    it('should use statistics object as sample', () => {
+      const { statisticsSample } = StatisticsFields.normalizeOptions({
+        statistics: { foo: '1.234' }
+      })
+      statisticsSample.should.deepEqual({ foo: '1.234' })
+    })
+
+    it('should defer to fieldsDefinitions when supplied', () => {
+      const { fieldDefinitions } = StatisticsFields.normalizeOptions({
+        fieldDefinitions: 'foo',
+        fields: 'bar',
+        metadata: {
+          fields: 'snafu'
+        }
+      })
+
+      fieldDefinitions.should.equal('foo')
+    })
+
+    it('should defer to root-level "fields" when supplied', () => {
+      const { fieldDefinitions } = StatisticsFields.normalizeOptions({
+        fields: 'bar',
+        metadata: {
+          fields: 'snafu'
+        }
+      })
+
+      fieldDefinitions.should.equal('bar')
+    })
+
+    it('should use "metadata.fields" when supplied', () => {
+      const { fieldDefinitions } = StatisticsFields.normalizeOptions({
+        metadata: {
+          fields: 'snafu'
+        }
+      })
+
+      fieldDefinitions.should.equal('snafu')
+    })
+
+    it('should convert groupByFieldsForStatistics string to array and remove whitespace', () => {
+      const { groupByFieldsForStatistics } = StatisticsFields.normalizeOptions({
+        groupByFieldsForStatistics: 'hello, world , today '
+      })
+
+      groupByFieldsForStatistics.should.deepEqual(['hello', 'world', 'today'])
+    })
+
+    it('should use groupByFieldsForStatistics array', () => {
+      const { groupByFieldsForStatistics } = StatisticsFields.normalizeOptions({
+        groupByFieldsForStatistics: ['hello']
+      })
+
+      groupByFieldsForStatistics.should.deepEqual(['hello'])
+    })
+
+    it('should default groupByFieldsForStatistics to empty array', () => {
+      const { groupByFieldsForStatistics } = StatisticsFields.normalizeOptions({})
+
+      groupByFieldsForStatistics.should.deepEqual([])
+    })
+  })
+
+  describe('static create method', () => {
+    it('should create fields from statistics and without definitions', () => {
+      const result = StatisticsFields.create({
+        statisticsSample: { foo: 1.234 }
+      })
+      result.should.deepEqual([{
+        name: 'foo',
+        type: 'esriFieldTypeDouble',
+        sqlType: 'sqlTypeFloat',
+        alias: 'foo',
+        domain: null,
+        defaultValue: null
+      }])
+    })
+
+    it('should create date field when value is ISO-string date', () => {
+      const result = StatisticsFields.create({
+        statisticsSample: { foo: new Date().toISOString() }
+      })
+      result.should.deepEqual([{
+        name: 'foo',
+        type: 'esriFieldTypeDate',
+        sqlType: 'sqlTypeOther',
+        alias: 'foo',
+        domain: null,
+        defaultValue: null
+      }])
+    })
+
+    it('should create date field when field is defined as date', () => {
+      const result = StatisticsFields.create({
+        statisticsSample: { foo: 100000 },
+        fieldDefinitions: [{ name: 'foo', type: 'Date' }],
+        outStatistics: [{ onStatisticField: 'foo' }]
+      })
+      result.should.deepEqual([{
+        name: 'foo',
+        type: 'esriFieldTypeDate',
+        sqlType: 'sqlTypeOther',
+        alias: 'foo',
+        domain: null,
+        defaultValue: null
+      }])
+    })
+
+    it('should create date field when field is defined as date, but custom label requested', () => {
+      const result = StatisticsFields.create({
+        statisticsSample: { bar: 100000 },
+        fieldDefinitions: [{ name: 'foo', type: 'Date' }],
+        outStatistics: [{ onStatisticField: 'foo', outStatisticFieldName: 'bar' }]
+      })
+      result.should.deepEqual([{
+        name: 'bar',
+        type: 'esriFieldTypeDate',
+        sqlType: 'sqlTypeOther',
+        alias: 'bar',
+        domain: null,
+        defaultValue: null
+      }])
+    })
+
+    it('should create date field and groupBy fields', () => {
+      const result = StatisticsFields.create({
+        statisticsSample: { foo: 100000, bar: 'hello', walter: 1 },
+        fieldDefinitions: [{ name: 'foo', type: 'Date' }],
+        outStatistics: [{ onStatisticField: 'foo' }],
+        groupByFieldsForStatistics: 'bar,walter'
+      })
+      result.should.deepEqual([{
+        name: 'foo',
+        type: 'esriFieldTypeDate',
+        sqlType: 'sqlTypeOther',
+        alias: 'foo',
+        domain: null,
+        defaultValue: null
+      }, {
+        name: 'bar',
+        type: 'esriFieldTypeString',
+        sqlType: 'sqlTypeOther',
+        length: 128,
+        alias: 'bar',
+        domain: null,
+        defaultValue: null
+      }, {
+        name: 'walter',
+        type: 'esriFieldTypeInteger',
+        sqlType: 'sqlTypeOther',
+        alias: 'walter',
+        domain: null,
+        defaultValue: null
+      }])
+    })
+  })
+})


### PR DESCRIPTION
This PR is second in a series that refactors the way FeatureServer generates the `fields` property in the responses for requests to `FeatureServer/:layer/query` and `FeatureServer/:layer/`. 

## Key background
 The `fields` property provides metadata for all of the properties/attributes on each feature.  For example:

https://services2.arcgis.com/zNjnZafDYCAJAbN0/ArcGIS/rest/services/Street_ROW_Trees/FeatureServer/2/query?resultRecordCount=1&outFields=*&where=1%3D1&f=pjson

```json
{
	"objectIdFieldName": "OBJECTID",
	"uniqueIdField": {
		"name": "OBJECTID",
		"isSystemMaintained": true
	},
	"globalIdFieldName": "",
	"geometryType": "esriGeometryPoint",
	"spatialReference": {
		"wkid": 102100,
		"latestWkid": 3857
	},
	"fields": [
		{
			"name": "OBJECTID",
			"type": "esriFieldTypeOID",
			"alias": "OBJECTID",
			"sqlType": "sqlTypeOther",
			"domain": null,
			"defaultValue": null
		},
		{
			"name": "Common_Name",
			"type": "esriFieldTypeString",
			"alias": "Common_Name",
			"sqlType": "sqlTypeOther",
			"length": 75,
			"domain": null,
			"defaultValue": null
		},
		{
			"name": "Genus",
			"type": "esriFieldTypeString",
			"alias": "Genus",
			"sqlType": "sqlTypeOther",
			"length": 50,
			"domain": null,
			"defaultValue": null
		},
		{
			"name": "Species",
			"type": "esriFieldTypeString",
			"alias": "Species",
			"sqlType": "sqlTypeOther",
			"length": 30,
			"domain": null,
			"defaultValue": null
		},
		{
			"name": "House_Number",
			"type": "esriFieldTypeInteger",
			"alias": "House_Number",
			"sqlType": "sqlTypeOther",
			"domain": null,
			"defaultValue": null
		},
		{
			"name": "Street_Direction",
			"type": "esriFieldTypeString",
			"alias": "Street_Direction",
			"sqlType": "sqlTypeOther",
			"length": 2,
			"domain": null,
			"defaultValue": null
		},
		{
			"name": "Street_Name",
			"type": "esriFieldTypeString",
			"alias": "Street_Name",
			"sqlType": "sqlTypeOther",
			"length": 50,
			"domain": null,
			"defaultValue": null
		},
		{
			"name": "Street_Type",
			"type": "esriFieldTypeString",
			"alias": "Street_Type",
			"sqlType": "sqlTypeOther",
			"length": 4,
			"domain": null,
			"defaultValue": null
		},
		{
			"name": "Street_Suffix",
			"type": "esriFieldTypeString",
			"alias": "Street_Suffix",
			"sqlType": "sqlTypeOther",
			"length": 5,
			"domain": null,
			"defaultValue": null
		},
		{
			"name": "Trunk_Diameter",
			"type": "esriFieldTypeDouble",
			"alias": "Trunk_Diameter",
			"sqlType": "sqlTypeOther",
			"domain": null,
			"defaultValue": null
		},
		{
			"name": "Longitude",
			"type": "esriFieldTypeDouble",
			"alias": "Longitude",
			"sqlType": "sqlTypeOther",
			"domain": null,
			"defaultValue": null
		},
		{
			"name": "Latitude",
			"type": "esriFieldTypeDouble",
			"alias": "Latitude",
			"sqlType": "sqlTypeOther",
			"domain": null,
			"defaultValue": null
		}
	],
	"exceededTransferLimit": true,
	"features": [
		{
			"attributes": {
				"OBJECTID": 1,
				"Common_Name": "AMERICAN SWEETGUM",
				"Genus": "LIQUIDAMBAR",
				"Species": "STYRACIFLUA",
				"House_Number": 3167,
				"Street_Direction": null,
				"Street_Name": "ALAMEDA",
				"Street_Type": "ST",
				"Street_Suffix": null,
				"Trunk_Diameter": 10,
				"Longitude": -118.085134478522,
				"Latitude": 34.153484325806
			},
			"geometry": {
				"x": -13145177.040404357,
				"y": 4049429.8874464519
			}
		}
	]
}
```
Each property in the feature's attributes is described in the `fields` array.

As noted above, the layer-info route also returns a `fields` array.  It's almost identical to what is returned in the query endpoint, _except_ that each field includes a _nullable_ and _editable_ boolean field:


https://services2.arcgis.com/zNjnZafDYCAJAbN0/ArcGIS/rest/services/Street_ROW_Trees/FeatureServer/2?f=pjson

```json
"fields" : [
    {
      "name" : "OBJECTID", 
      "type" : "esriFieldTypeOID", 
      "alias" : "OBJECTID", 
      "sqlType" : "sqlTypeOther", 
      "nullable" : false, 
      "editable" : false, 
      "domain" : null, 
      "defaultValue" : null
    }, 
    {
      "name" : "Common_Name", 
      "type" : "esriFieldTypeString", 
      "alias" : "Common_Name", 
      "sqlType" : "sqlTypeOther", 
      "length" : 75, 
      "nullable" : true, 
      "editable" : true, 
      "domain" : null, 
      "defaultValue" : null
    }, 
...
...
]
```

The query endpoint contains one known variation, and this occurs when statistical aggregations have been requested (i.e., `outStatistics` parameter):

[statistics query](https://services2.arcgis.com/zNjnZafDYCAJAbN0/ArcGIS/rest/services/Street_ROW_Trees/FeatureServer/2/query?where=1%3D1&objectIds=&time=&geometry=&geometryType=esriGeometryEnvelope&inSR=&spatialRel=esriSpatialRelIntersects&resultType=none&distance=0.0&units=esriSRUnit_Meter&returnGeodetic=false&outFields=&returnGeometry=true&featureEncoding=esriDefault&multipatchOption=xyFootprint&maxAllowableOffset=&geometryPrecision=&outSR=&defaultSR=&datumTransformation=&applyVCSProjection=false&returnIdsOnly=false&returnUniqueIdsOnly=false&returnCountOnly=false&returnExtentOnly=false&returnQueryGeometry=false&returnDistinctValues=false&cacheHint=false&orderByFields=&groupByFieldsForStatistics=&outStatistics=%5B%7B%0D%0A++++++++++++statisticType%3A+%27sum%27%2C%0D%0A++++++++++++onStatisticField%3A+%27Trunk_Diameter%27%2C%0D%0A++++++++++++outStatisticFieldName%3A+%27TOTAL_STUD_SUM%27%0D%0A++++++++++%7D%2C+%7B%0D%0A++++++++++++statisticType%3A+%27max%27%2C%0D%0A++++++++++++onStatisticField%3A+%27Trunk_Diameter%27%2C%0D%0A++++++++++++outStatisticFieldName%3A+%27ZIP_CODE_COUNT%27%0D%0A++++++++++%7D%5D&having=&resultOffset=&resultRecordCount=&returnZ=false&returnM=false&returnExceededLimitFeatures=true&quantizationParameters=&sqlFormat=none&f=pjson&token=)

```json
{
  "objectIdFieldName" : "OBJECTID", 
  "uniqueIdField" : 
  {
    "name" : "OBJECTID", 
    "isSystemMaintained" : true
  }, 
  "globalIdFieldName" : "", 
  "geometryType" : "esriGeometryPoint", 
  "spatialReference" : {
    "wkid" : 102100, 
    "latestWkid" : 3857
  }, 
  "fields" : [
    {
      "name" : "TOTAL_STUD_SUM", 
      "type" : "esriFieldTypeDouble", 
      "alias" : "TOTAL_STUD_SUM", 
      "sqlType" : "sqlTypeFloat", 
      "domain" : null, 
      "defaultValue" : null
    }, 
    {
      "name" : "ZIP_CODE_COUNT", 
      "type" : "esriFieldTypeDouble", 
      "alias" : "ZIP_CODE_COUNT", 
      "sqlType" : "sqlTypeFloat", 
      "domain" : null, 
      "defaultValue" : null
    }
  ], 
  "features" : [
    {
      "attributes" : {
        "TOTAL_STUD_SUM" : 897872.999999995, 
        "ZIP_CODE_COUNT" : 263.5
      }
    }
  ]
}
```

Note here that ALL statistics fields with the exception of dates are tagged as type `esriFieldTypeDouble` regardless of their source field's type.  So even if you do a SUM of an integer type, the resulting statistics field is type double.  Any groupBy fields are typed as their source field's type.

## PR content
This PR _contains only the new code_ used for fields-array generation for the three cases noted above: query, layer-info, query-statistics.  You will see that there are two ways field objects can be generated - either from a field definition that is attached the metadata of the provider or by inspecting the data type of a sample value from the feature set.

This PR does not contain the implementation of the new field generation code in the response handler.  That will come in a follow-up PR - this is an effort to decrease the scope of each individual PR.