### PR TITLE
Set default descriptions via app.locals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 ### Added
 - override default currentVersion and fullVersion via app.locals.config.featureServer
+- override default service-description and layer-description via app.locals.config.featureServer
 
 ## [3.5.1] - 06-01-2022
 ### Changed

--- a/README.md
+++ b/README.md
@@ -53,32 +53,14 @@ The follow properties can be set at runtime with the noted method:
 ```js
 app.locals.config = {
   featureServer: {
-    currentVersion: <feature-server version you are mocking>, // default 10.51
-    fullVersion: <feature-server version you are mocking>, // default '10.5.1'
-    serviceDescription: <the default service description>,
-    description: <the default layer description>
-  }
-}
-```
-#### Version
-By default, the service and layer metadata endpoints will respond with the following version attributes:
-```json
-currentVersion: 10.51,
-fullVersion: '10.5.1'
-```
-
-You can alter these defaults by setting properties on Express's `app.locals`:
-
-```js
-app.locals.config = {
-  featureServer: {
-    currentVersion: 10.81,
-    fullVersion: '10.8.1'
+    currentVersion: 11.01, // defaults to 10.51
+    fullVersion: '11.0.1', // defaults to '10.5.1'
+    serviceDescription: 'default service description',
+    description: 'default layer description'
   }
 }
 ```
 
-#### Service Description
 ## API
 * [FeatureServer.route](#FeatureServer.route)
 * [FeatureServer.query](#FeatureServer.query)

--- a/README.md
+++ b/README.md
@@ -35,7 +35,32 @@ routes.forEach(route => {
 })
 ```
 
-### Version Configuration
+### Setting defaults at runtime
+FeatureServer allows several defaults to be set at runtime via Express's `app.locals` method.  Specifically, you will need to set:
+
+```js
+app.locals.config = {
+  featureServer: {
+    // define default here
+  }
+}
+```
+
+If you are using FeatureServer as part of a Koop instance, the equivalent of Express's `app.locals` is `koop.server.locals`.
+
+The follow properties can be set at runtime with the noted method:
+
+```js
+app.locals.config = {
+  featureServer: {
+    currentVersion: <feature-server version you are mocking>, // default 10.51
+    fullVersion: <feature-server version you are mocking>, // default '10.5.1'
+    serviceDescription: <the default service description>,
+    description: <the default layer description>
+  }
+}
+```
+#### Version
 By default, the service and layer metadata endpoints will respond with the following version attributes:
 ```json
 currentVersion: 10.51,
@@ -52,9 +77,8 @@ app.locals.config = {
   }
 }
 ```
-Note, if you are using FeatureServer as part of the Koop platform, the equivalent of Express's `app.locals` is `koop.server.locals`.
 
-
+#### Service Description
 ## API
 * [FeatureServer.route](#FeatureServer.route)
 * [FeatureServer.query](#FeatureServer.query)

--- a/lib/helpers/table-layer-metadata.js
+++ b/lib/helpers/table-layer-metadata.js
@@ -25,21 +25,27 @@ class TableLayerMetadata {
     } = geojson
 
     const {
-      params: { layer: layerId } = {},
+      params: {
+        layer: layerId
+      } = {},
       query = {}
     } = req
 
-    const currentVersion = _.get(req, 'app.locals.config.featureServer.currentVersion', CURRENT_VERSION)
-    const fullVersion = _.get(req, 'app.locals.config.featureServer.fullVersion', FULL_VERSION)
-
-    const normalizedOptions = {
-      layerId,
+    const {
       currentVersion,
       fullVersion,
+      description
+    } = _.get(req, 'app.locals.config.featureServer', {})
+
+    const normalizedOptions = _.pickBy({
+      currentVersion,
+      fullVersion,
+      description,
+      layerId,
       ...query,
       ...metadata,
       capabilities: normalizeCapabilities(capabilities, metadata.capabilities)
-    }
+    }, (value) => value)
 
     if (!normalizedGeojson.features) {
       normalizedGeojson.features = []

--- a/lib/server-info-route-handler.js
+++ b/lib/server-info-route-handler.js
@@ -19,8 +19,14 @@ function serverMetadata (json, req = {}) {
     query = {}
   } = req
 
-  const { extent, metadata, ...rest } = json
-  const { maxRecordCount, hasStaticData, description, copyrightText } = { ...metadata, ...rest }
+  const { extent, metadata = {}, ...rest } = json
+  const {
+    maxRecordCount,
+    hasStaticData,
+    copyrightText,
+    description: providerLayerDescription,
+    serviceDescription: providerServiceDescription
+  } = { ...metadata, ...rest }
   const spatialReference = getSpatialReference(json, query)
   const { layers, tables, relationships } = normalizeInputData(json)
   // TODO reproject default extents when non WGS84 CRS is found or passed
@@ -29,7 +35,7 @@ function serverMetadata (json, req = {}) {
   const {
     currentVersion = CURRENT_VERSION,
     fullVersion = FULL_VERSION,
-    serviceDescription = description
+    serviceDescription
   } = _.get(req, 'app.locals.config.featureServer', {})
 
   return _.defaults({
@@ -44,7 +50,7 @@ function serverMetadata (json, req = {}) {
     }),
     relationships: relationships.map(relationshipInfo),
     supportsRelationshipsResource: relationships && relationships.length > 0,
-    serviceDescription,
+    serviceDescription: serviceDescription || providerServiceDescription || providerLayerDescription,
     copyrightText: copyrightText,
     maxRecordCount: maxRecordCount || _.get(layers, '[0].metadata.maxRecordCount'),
     hasStaticData: typeof hasStaticData === 'boolean' ? hasStaticData : false

--- a/lib/server-info-route-handler.js
+++ b/lib/server-info-route-handler.js
@@ -18,16 +18,19 @@ function serverMetadata (json, req = {}) {
   const {
     query = {}
   } = req
-  const currentVersion = _.get(req, 'app.locals.config.featureServer.currentVersion', CURRENT_VERSION)
-  const fullVersion = _.get(req, 'app.locals.config.featureServer.fullVersion', FULL_VERSION)
 
   const { extent, metadata, ...rest } = json
   const { maxRecordCount, hasStaticData, description, copyrightText } = { ...metadata, ...rest }
   const spatialReference = getSpatialReference(json, query)
   const { layers, tables, relationships } = normalizeInputData(json)
+  // TODO reproject default extents when non WGS84 CRS is found or passed
   const fullExtent = getServiceExtent({ extent, metadata, layers, spatialReference })
 
-  // TODO reproject default extents when non WGS84 CRS is found or passed
+  const {
+    currentVersion = CURRENT_VERSION,
+    fullVersion = FULL_VERSION,
+    serviceDescription = description
+  } = _.get(req, 'app.locals.config.featureServer', {})
 
   return _.defaults({
     currentVersion,
@@ -41,7 +44,7 @@ function serverMetadata (json, req = {}) {
     }),
     relationships: relationships.map(relationshipInfo),
     supportsRelationshipsResource: relationships && relationships.length > 0,
-    serviceDescription: description,
+    serviceDescription,
     copyrightText: copyrightText,
     maxRecordCount: maxRecordCount || _.get(layers, '[0].metadata.maxRecordCount'),
     hasStaticData: typeof hasStaticData === 'boolean' ? hasStaticData : false

--- a/test/unit/helpers/table-layer-metadata.spec.js
+++ b/test/unit/helpers/table-layer-metadata.spec.js
@@ -281,36 +281,55 @@ describe('TableLayerMetadata', () => {
     geojson.should.deepEqual({ features: ['feature'] })
     options.should.deepEqual({
       capabilities: {},
-      layerId: '99',
-      currentVersion: CURRENT_VERSION,
-      fullVersion: FULL_VERSION
+      layerId: '99'
     })
   })
 
-  it('static method "normalizeInput" should create expected geojson and options', () => {
+  it('static method "normalizeInput" should merge capabilities', () => {
     const { geojson, options } = TableLayerMetadata.normalizeInput({
       features: ['feature'],
       metadata: {
-        foo: 'bar',
         capabilities: 'list,of,stuff'
       },
       capabilities: {
         world: 'hellow'
       }
     }, {
-      params: { layer: '99' },
-      app: { locals: { config: { featureServer: { currentVersion: 90.99, fullVersion: '90.9.9' } } } }
+      params: { layer: '99' }
     })
     geojson.should.deepEqual({ features: ['feature'] })
     options.should.deepEqual({
-      foo: 'bar',
       layerId: '99',
       capabilities: {
         list: 'list,of,stuff',
         world: 'hellow'
-      },
-      currentVersion: 90.99,
-      fullVersion: '90.9.9'
+      }
+    })
+  })
+
+  it('static method "normalizeInput" should defer to metadata description', () => {
+    const { geojson, options } = TableLayerMetadata.normalizeInput({
+      features: ['feature'],
+      metadata: {
+        description: 'Metadata description'
+      }
+    }, {
+      params: { layer: '99' },
+      app: {
+        locals: {
+          config: {
+            featureServer: {
+              description: 'Overrides default layer description.'
+            }
+          }
+        }
+      }
+    })
+    geojson.should.deepEqual({ features: ['feature'] })
+    options.should.deepEqual({
+      layerId: '99',
+      description: 'Metadata description',
+      capabilities: {}
     })
   })
 
@@ -326,8 +345,18 @@ describe('TableLayerMetadata', () => {
         world: 'hellow'
       }
     }, {
-
-      params: { layer: '99' }
+      params: { layer: '99' },
+      app: {
+        locals: {
+          config: {
+            featureServer: {
+              currentVersion: 90.99,
+              fullVersion: '90.9.9',
+              description: 'Overrides default layer description.'
+            }
+          }
+        }
+      }
     })
     tableLayerMetadata.should.deepEqual({
       ...defaultFixture,
@@ -335,8 +364,9 @@ describe('TableLayerMetadata', () => {
       displayField: 'myField',
       fields: ['fields'],
       id: 99,
-      currentVersion: CURRENT_VERSION,
-      fullVersion: FULL_VERSION
+      currentVersion: 90.99,
+      fullVersion: '90.9.9',
+      description: 'Overrides default layer description.'
     })
   })
 })

--- a/test/unit/server-info-route-handler.spec.js
+++ b/test/unit/server-info-route-handler.spec.js
@@ -713,7 +713,7 @@ describe('server info', () => {
     })
   })
 
-  it('should use req.app.locals.config.featureServer for version', () => {
+  it('should use req.app.locals.config.featureServer for version and serviceDescription', () => {
     const simpleCollectionFixture = {
       type: 'FeatureCollection',
       crs: {
@@ -782,7 +782,11 @@ describe('server info', () => {
       app: {
         locals: {
           config: {
-            featureServer: { currentVersion: 11.01, fullVersion: '11.0.1' }
+            featureServer: {
+              currentVersion: 11.01,
+              fullVersion: '11.0.1',
+              serviceDescription: 'Overrides default service description'
+            }
           }
         }
       }
@@ -803,7 +807,7 @@ describe('server info', () => {
     serverInfo.should.deepEqual({
       foo: 'bar',
       maxRecordCount: 'max-record-count',
-      serviceDescription: 'service-description',
+      serviceDescription: 'Overrides default service description',
       copyrightText: 'copyright-text',
       hasStaticData: false,
       supportsRelationshipsResource: false,


### PR DESCRIPTION
This PR allow the service-description and the layer-description to be set at run-time via Express's `app.locals`.