### PR TITLE
Set hasZ from GeoJSON metadata when available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+## Added
+- Set hasZ from metadata setting when present
+
 ## [4.0.1] - 08-05-2022
 ### Changed
 - bump winnow version

--- a/lib/helpers/table-layer-metadata.js
+++ b/lib/helpers/table-layer-metadata.js
@@ -213,7 +213,8 @@ class TableLayerMetadata {
       maxRecordCount,
       defaultVisibility,
       currentVersion,
-      fullVersion
+      fullVersion,
+      hasZ
     } = options
 
     _.merge(this, {
@@ -227,7 +228,8 @@ class TableLayerMetadata {
       maxRecordCount,
       defaultVisibility,
       currentVersion,
-      fullVersion
+      fullVersion,
+      hasZ
     })
   }
 }

--- a/test/unit/helpers/table-layer-metadata.spec.js
+++ b/test/unit/helpers/table-layer-metadata.spec.js
@@ -151,6 +151,18 @@ describe('TableLayerMetadata', () => {
       })
     })
 
+    it('"hasZ" option used when present in metadata', () => {
+      const tableLayerMetadata = new TableLayerMetadata()
+      tableLayerMetadata.mixinOverrides({}, { hasZ: true })
+
+      tableLayerMetadata.should.deepEqual({
+        ...defaultFixture,
+        fields: ['fields'],
+        hasZ: true
+      })
+    })
+
+
     it('"hasStaticData" option used if a boolean value', () => {
       const tableLayerMetadata = new TableLayerMetadata()
       tableLayerMetadata.mixinOverrides({}, { hasStaticData: true })

--- a/test/unit/helpers/table-layer-metadata.spec.js
+++ b/test/unit/helpers/table-layer-metadata.spec.js
@@ -162,7 +162,6 @@ describe('TableLayerMetadata', () => {
       })
     })
 
-
     it('"hasStaticData" option used if a boolean value', () => {
       const tableLayerMetadata = new TableLayerMetadata()
       tableLayerMetadata.mixinOverrides({}, { hasStaticData: true })


### PR DESCRIPTION
The `hasZ` setting on the layer-info route is currently hardcoded to `false`, but should be true when data includes Z-coordinates.  This PR allows GeoJSON metadata to override the default.  If the GeoJSON looks like:

```js
{
  metadata: {
    hasZ: true
  }
}
```

then the `hasZ` in the layer-info response will also be true.  So a Koop-provider can set the `geojson.metadata.hasZ` value if it knows the data has Z coordinates, and FeatureServer will respond appropriately.