### PR TITLE
Fix inconsistent args with FeatureLayerMetadata.create and QueryFields.create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 ### Fixed
 - geojson validation security vulnerablity
+- fix ids in layers metadata
+- fix params passed to QueryFields.create
 
 ## [4.0.1] - 08-05-2022
 ### Changed

--- a/lib/helpers/table-layer-metadata.js
+++ b/lib/helpers/table-layer-metadata.js
@@ -26,10 +26,12 @@ class TableLayerMetadata {
 
     const {
       params: {
-        layer: layerId
+        layer: reqLayer
       } = {},
       query = {}
     } = req
+
+    const layerId = reqLayer != null ? reqLayer : req.layerId
 
     const {
       currentVersion,

--- a/lib/query/render-features.js
+++ b/lib/query/render-features.js
@@ -33,7 +33,7 @@ function renderFeaturesResponse (data = {}, params = {}) {
   const computedProperties = {
     geometryType: params.geometryType,
     spatialReference: getOutputSpatialReference(data, params),
-    fields: QueryFields.create({ data, ...params }),
+    fields: QueryFields.create({ ...data, ...params }),
     features: data.features || [],
     exceededTransferLimit: !!limitExceeded,
     objectIdFieldName: idField || objectIdFieldNameDefault,

--- a/lib/queryRelatedRecords.js
+++ b/lib/queryRelatedRecords.js
@@ -11,7 +11,7 @@ function queryRelatedRecords (data, params = {}) {
     relatedRecordGroups: []
   }
 
-  if (!params.returnCountOnly) response.fields = QueryFields.create(data, params)
+  if (!params.returnCountOnly) response.fields = QueryFields.create({ ...data, ...params })
 
   const geomType = getGeometryTypeFromGeojson(data)
   if (geomType) {

--- a/test/unit/query/render-features.spec.js
+++ b/test/unit/query/render-features.spec.js
@@ -79,7 +79,7 @@ describe('renderFeaturesResponse', () => {
       exceededTransferLimit: false
     })
     createQueryFieldsSpy.callCount.should.equal(1)
-    createQueryFieldsSpy.firstCall.args.should.deepEqual([{ data: json, geometryType: 'esriGeometryPoint' }])
+    createQueryFieldsSpy.firstCall.args.should.deepEqual([{ ...json, geometryType: 'esriGeometryPoint' }])
     getCollectionCrsSpy.callCount.should.equal(1)
     getCollectionCrsSpy.firstCall.args.should.deepEqual([json])
     normalizeSpatialReferenceSpy.callCount.should.equal(1)
@@ -134,7 +134,7 @@ describe('renderFeaturesResponse', () => {
       transform: 'transform'
     })
     createQueryFieldsSpy.callCount.should.equal(1)
-    createQueryFieldsSpy.firstCall.args.should.deepEqual([{ data: json, geometryType: 'esriGeometryPoint' }])
+    createQueryFieldsSpy.firstCall.args.should.deepEqual([{ ...json, geometryType: 'esriGeometryPoint' }])
     getCollectionCrsSpy.callCount.should.equal(1)
     getCollectionCrsSpy.firstCall.args.should.deepEqual([json])
     normalizeSpatialReferenceSpy.callCount.should.equal(1)


### PR DESCRIPTION
This resolves a couple bugs related to how options are normalized in various parts of the library.

The first is explained in #240, but essentially `FeatureLayerMetadata.create` calls `TableLayerMetadata.normalizeInput` with inconsistent options. The normalize call expects the `layerId` to be under `req.params.layer` (this is the case when making a layer request), but when requesting layers metadata from the `/layers` endpoint the layerId is under `req.layerId`.

https://github.com/koopjs/FeatureServer/blob/878c38ffd3ec65870a22df0ee209f3015cf8866d/lib/helpers/table-layer-metadata.js#L27-L32

https://github.com/koopjs/FeatureServer/blob/878c38ffd3ec65870a22df0ee209f3015cf8866d/lib/layers-metadata.js#L10-L12

The `normalizeOptions` call for QueryFields/Fields does not expect a `data` property. The fields within `data` are expected to be directly in the `inputOptions`.
https://github.com/koopjs/FeatureServer/blob/878c38ffd3ec65870a22df0ee209f3015cf8866d/lib/helpers/fields/fields.js#L10-L20

For the `queryRelatedRecords` case, two input arguments are passed when only one is expected (`inputOptions`).

Resolves #240.