### PR TITLE
editable/nullable by field definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Fixed
+- Allow field definitions to set editable and nullable properties
+
 ## [4.1.0] - 09-15-2022
 ### Added
 - Set hasZ from metadata setting when present

--- a/lib/helpers/fields/layer-fields.js
+++ b/lib/helpers/fields/layer-fields.js
@@ -10,10 +10,16 @@ class LayerFields extends Fields {
     super(options)
 
     return this.fields.map(field => {
-      field.setEditable().setNullable()
+      const { editable = false, nullable = false } = findDefinition(field.name, options.fieldDefinitions)
+      field.setEditable(editable).setNullable(nullable)
       return field
     })
   }
 }
 
+function findDefinition (fieldName, fieldDefinitions = []) {
+  return fieldDefinitions.find(definition => {
+    return definition.name === fieldName
+  }) || {}
+}
 module.exports = LayerFields

--- a/test/integration/info.spec.js
+++ b/test/integration/info.spec.js
@@ -215,7 +215,8 @@ describe('Info operations', () => {
             {
               name: 'test',
               type: 'String',
-              length: 1000
+              length: 1000,
+              editable: true
             }
           ]
         }

--- a/test/unit/helpers/fields/layer-fields.spec.js
+++ b/test/unit/helpers/fields/layer-fields.spec.js
@@ -6,7 +6,8 @@ describe('LayerFields', () => {
   it('create fields from definitions, adds OBJECTID', () => {
     const result = LayerFields.create({
       fields: [
-        { name: 'foo', type: 'String' }
+        { name: 'foo', type: 'String' },
+        { name: 'bar', type: 'String', editable: true, nullable: true }
       ]
     })
     result.should.deepEqual([{
@@ -28,6 +29,16 @@ describe('LayerFields', () => {
       defaultValue: null,
       editable: false,
       nullable: false
+    }, {
+      name: 'bar',
+      alias: 'bar',
+      type: 'esriFieldTypeString',
+      sqlType: 'sqlTypeOther',
+      length: 128,
+      domain: null,
+      defaultValue: null,
+      editable: true,
+      nullable: true
     }])
   })
 


### PR DESCRIPTION
Fixing regression where `editable` and `nullable` field props were not set by field defintion.